### PR TITLE
Bug fixes: wrong test cases, concurrency issues, unregister handlers

### DIFF
--- a/back-end/apis/predict.py
+++ b/back-end/apis/predict.py
@@ -101,15 +101,17 @@ def predict(split):
     else:
         # get predict results
         try:
+            modelWrapper.lock.acquire()
             output = get_image_prediction(modelWrapper, image_path, dataManager.image_size, argmax=False)
         except Exception as e:
             return RResponse.fail('Invalid image path {}'.format(image_path))
+        finally:
+            modelWrapper.lock.release()
         output_array = convert_predict_to_array(output.cpu().detach().numpy())
 
         # get visualize images
         image_name = image_path.replace('.', '_').replace('/', '_').replace('\\', '_')
-        model = modelWrapper.model
-        output = visualize(model, image_path, dataManager.image_size, server.configs['device'])
+        output = visualize(modelWrapper, image_path, dataManager.image_size, server.configs['device'])
         if len(output) != 4:
             return RResponse.fail("[Unexpected] Invalid number of predict visualize figures")
 

--- a/back-end/modules/visualize_module/visualize/visual.py
+++ b/back-end/modules/visualize_module/visualize/visual.py
@@ -1,3 +1,4 @@
+from objects.RModelWrapper import RModelWrapper
 from ..flashtorch_.utils import apply_transforms, load_image
 from ..flashtorch_.saliency import Backprop
 import torch, matplotlib
@@ -7,18 +8,26 @@ import matplotlib.pyplot as plt
 
 
 # https://github.com/MisaOgura/flashtorch#saliency-maps-flashtorchsaliency
-def visualize(mymodel, imgpath, imgsize, device):
-    backprop = Backprop(mymodel)
-    image = load_image(imgpath)
-    image = apply_transforms(image, imgsize)
+def visualize(modelWrapper: RModelWrapper, imgpath, imgsize, device):
+    mymodel = modelWrapper.model
+    modelWrapper.lock.acquire()
+    images = []
+    try: 
+        backprop = Backprop(mymodel)
+        image = load_image(imgpath)
+        image = apply_transforms(image, imgsize)
 
-    modeloutput = backprop.model(image.to(device))
-    modeloutput = torch.nn.functional.softmax(modeloutput, 1)
+        modeloutput = backprop.model(image.to(device))
+        modeloutput = torch.nn.functional.softmax(modeloutput, 1)
 
-    _, predict = torch.max(modeloutput, 1)
-    use_gpu = device != 'cpu'
-    images = backprop.visualize(image, predict, guided=True, return_image=True, use_gpu=use_gpu)
-    backprop.unregister_hooks()
+        _, predict = torch.max(modeloutput, 1)
+        use_gpu = device != 'cpu'
+        images = backprop.visualize(image, predict, guided=True, return_image=True, use_gpu=use_gpu)
+        backprop.unregister_hooks()
+    except Exception as e:
+        print(str(e))
+    finally:
+        modelWrapper.lock.release()
 
     return images
 

--- a/back-end/modules/visualize_module/visualize/visual.py
+++ b/back-end/modules/visualize_module/visualize/visual.py
@@ -18,6 +18,7 @@ def visualize(mymodel, imgpath, imgsize, device):
     _, predict = torch.max(modeloutput, 1)
     use_gpu = device != 'cpu'
     images = backprop.visualize(image, predict, guided=True, return_image=True, use_gpu=use_gpu)
+    backprop.unregister_hooks()
 
     return images
 

--- a/back-end/objects/RModelWrapper.py
+++ b/back-end/objects/RModelWrapper.py
@@ -1,11 +1,15 @@
 import torch
 import torchvision
 import os
+from threading import Lock
 
 IMAGENET_OUTPUT_SIZE = 1000
 
 
 class RModelWrapper:
+
+    lock = Lock()
+
     # model=Model("resnet-18-32x32",'./model/weight/resnet18_cifar_model.pth','cpu')
     def __init__(self, network_type, net_path, device, pretrained, num_classes):
         # self.device = torch.device(device)
@@ -56,10 +60,3 @@ class RModelWrapper:
                 path, map_location=self.device))
         else:
             print('weight file not found')
-
-    # Duplicated code
-    # def apply_cuda(self):
-    #     self.device = torch.device(self.device)
-    #     if self.model:
-    #         self.model = self.model.to(self.device)
-    #     return self

--- a/front-end/cypress/tests/components/auto_annotate_pad.spec.js
+++ b/front-end/cypress/tests/components/auto_annotate_pad.spec.js
@@ -16,8 +16,13 @@ describe('Auto Annotate Pad', () => {
   it('Test Annotated Images url', () => {
     cy.getBySel('auto-annotate-start-index').clear().type('1');
     cy.getBySel('auto-annotate-end-index').clear().type('3');
-    cy.clickBySel('auto-annotate-pad-start-auto-annotation');
-    cy.wait(20000);
+    cy.getBySel('header-toggle-tasks-panel').click();
+    cy.getBySel('auto-annotate-pad-start-auto-annotation').click();
+
+    // This will wait for max 120 seconds until the task is finished
+    cy.get('task-panel-stop-task'); // Wait until task pops up
+    cy.get('[data-test=task-center-p-no-task]', { timeout: 120 * 1000 });
+
     cy.contains('Inspect Data').click();
     cy.contains('Annotated Data').click();
     cy.url().should('include', '/image-list/annotated');
@@ -33,14 +38,14 @@ describe('Auto Annotate Pad', () => {
     cy.clickBySel('auto-annotate-pad-start-auto-annotation');
     cy.getBySel('task-panel-item-name').children().should('have.length', 1);
     cy.clickBySel('task-panel-stop-task');
-    cy.get('p').should('have.text', 'No task is running now.');
+    cy.getBySel('task-center-p-no-task').should('be.visible');
   });
 
   it('Test Input Zero', () => {
     cy.getBySel('header-toggle-tasks-panel').click();
     cy.getBySel('auto-annotate-end-index').clear().type('0');
     cy.clickBySel('auto-annotate-pad-start-auto-annotation');
-    cy.get('p').should('have.text', 'No task is running now.');
+    cy.getBySel('task-center-p-no-task').should('be.visible');
   });
 
   it('Test Input Zero Before Integer', () => {
@@ -64,21 +69,21 @@ describe('Auto Annotate Pad', () => {
     cy.getBySel('header-toggle-tasks-panel').click();
     cy.getBySel('auto-annotate-end-index').clear().type('9.9');
     cy.clickBySel('auto-annotate-pad-start-auto-annotation');
-    cy.get('p').should('have.text', 'No task is running now.');
+    cy.getBySel('task-center-p-no-task').should('be.visible');
   });
 
   it('Test Start index be negative number', () => {
     cy.getBySel('header-toggle-tasks-panel').click();
     cy.getBySel('auto-annotate-start-index').clear().type('-1');
     cy.getBySel('auto-annotate-pad-start-auto-annotation').click();
-    cy.get('p').should('have.text', 'No task is running now.');
+    cy.getBySel('task-center-p-no-task').should('be.visible');
   });
 
   it('Test End index be less than -1', () => {
     cy.getBySel('header-toggle-tasks-panel').click();
     cy.getBySel('auto-annotate-end-index').clear().type('-2');
     cy.getBySel('auto-annotate-pad-start-auto-annotation').click();
-    cy.get('p').should('have.text', 'No task is running now.');
+    cy.getBySel('task-center-p-no-task').should('be.visible');
   });
 
   it('Test End index be less than Start index', () => {
@@ -86,6 +91,6 @@ describe('Auto Annotate Pad', () => {
     cy.getBySel('auto-annotate-start-index').clear().type('99999');
     cy.getBySel('auto-annotate-end-index').clear().type('99998');
     cy.getBySel('auto-annotate-pad-start-auto-annotation').click();
-    cy.get('p').should('have.text', 'No task is running now.');
+    cy.getBySel('task-center-p-no-task').should('be.visible');
   });
 });

--- a/front-end/cypress/tests/components/auto_annotate_pad.spec.js
+++ b/front-end/cypress/tests/components/auto_annotate_pad.spec.js
@@ -14,13 +14,13 @@ describe('Auto Annotate Pad', () => {
   });
 
   it('Test Annotated Images url', () => {
-    cy.getBySel('auto-annotate-start-index').clear().type('1');
-    cy.getBySel('auto-annotate-end-index').clear().type('3');
+    cy.getBySel('auto-annotate-start-index').clear().type('21');
+    cy.getBySel('auto-annotate-end-index').clear().type('23');
     cy.getBySel('header-toggle-tasks-panel').click();
     cy.getBySel('auto-annotate-pad-start-auto-annotation').click();
 
     // This will wait for max 120 seconds until the task is finished
-    cy.get('task-panel-stop-task'); // Wait until task pops up
+    cy.wait(4000);
     cy.get('[data-test=task-center-p-no-task]', { timeout: 120 * 1000 });
 
     cy.contains('Inspect Data').click();
@@ -54,6 +54,7 @@ describe('Auto Annotate Pad', () => {
     cy.clickBySel('auto-annotate-pad-start-auto-annotation');
     cy.getBySel('task-panel-progress-linear').should('contain', '999');
     cy.clickBySel('task-panel-stop-task');
+    cy.getBySel('task-center-p-no-task').should('be.visible');
   });
 
   it('Test Input Big Integer', () => {
@@ -63,6 +64,7 @@ describe('Auto Annotate Pad', () => {
     cy.getBySel('task-panel-item-name').children().should('have.length', 1);
     cy.getBySel('task-panel-progress-linear').should('contain', '9000');
     cy.clickBySel('task-panel-stop-task');
+    cy.getBySel('task-center-p-no-task').should('be.visible');
   });
 
   it('Test Input Floating Point Number', () => {

--- a/front-end/cypress/tests/components/auto_annotate_pad.spec.js
+++ b/front-end/cypress/tests/components/auto_annotate_pad.spec.js
@@ -1,12 +1,16 @@
 describe('Auto Annotate Pad', () => {
-  afterEach(() => {
+  after(() => {
     cy.visit('http://localhost:8080/#/image-list/annotated');
     cy.getBySel('image-list-btn-clear-annotated-imgs').click();
     cy.wait(500);
   });
 
   beforeEach(() => {
+    cy.visit('http://localhost:8080/#/image-list/annotated');
+    cy.getBySel('image-list-btn-clear-annotated-imgs').click();
+    cy.wait(500);
     cy.visit('http://localhost:8080/#/auto-annotate');
+    cy.wait(500);
   });
 
   it('Test Annotated Images url', () => {

--- a/front-end/packages/robustar/src/components/common/TaskPanel.vue
+++ b/front-end/packages/robustar/src/components/common/TaskPanel.vue
@@ -15,7 +15,7 @@
       >
         <v-row align="center" justify="center">
           <v-col cols="12" lg="12" align="center" justify="center" v-if="digest.length == 0">
-            <p style="color: gray">No task is running now.</p>
+            <p data-test="task-center-p-no-task" style="color: gray">No task is running now.</p>
           </v-col>
         </v-row>
         <!-- <v-row v-for="(item, index) in digest" align="center" justify="center" :key="item[0]"> -->

--- a/front-end/packages/robustar/src/views/ImageList.vue
+++ b/front-end/packages/robustar/src/views/ImageList.vue
@@ -424,7 +424,7 @@ export default {
       this.isLoadingImages = true;
       try {
         const res = await APIGetImageListDebounced(this.split, this.currentPage, this.imagePerPage);
-        const list = res.data.data;
+        const list = res.data.data || [];
         this.$nextTick(() => {
           this.imageList = [];
           list.forEach((imagePath) => {


### PR DESCRIPTION
1. Update test cases to wait for things to happen in a better way
2. Unregister hooks after visualization is done
3. Querying the model is prevented during saliency calculation. Achieved with simple locks.