### PR TITLE
Added support for validation set

### DIFF
--- a/launcher/controllers/main_ctrl.py
+++ b/launcher/controllers/main_ctrl.py
@@ -32,14 +32,17 @@ class MainController(QObject):
             self.dockerCtrl.refreshServers()
             self.mainView.show()
         except requests.RequestException as e:
-            self.popupView.ui.warningLabel.setText(f'Failed to fetch image versions online!\nPlease check your network!')
+            self.popupView.ui.warningLabel.setText(
+                f"Failed to fetch image versions online!\nPlease check your network!"
+            )
             self.popupView.ui.exceptionLabel.setText(str(e))
             self.popupView.show()
         except docker.errors.DockerException as e:
-            self.popupView.ui.warningLabel.setText('Docker is not running!\nPlease start Docker first!')
+            self.popupView.ui.warningLabel.setText(
+                "Docker is not running!\nPlease start Docker first!"
+            )
             self.popupView.ui.exceptionLabel.setText(str(e))
             self.popupView.show()
-
 
     # Slot functions to change the model
     def setMContainerName(self):
@@ -52,19 +55,33 @@ class MainController(QObject):
         self.model.port = self.mainView.ui.portInput.text()
 
     def setMTrainPath(self):
-        path = QFileDialog.getExistingDirectory(self.mainView, "Choose Train Set Path", self.model.cwd)
+        path = QFileDialog.getExistingDirectory(
+            self.mainView, "Choose Train Set Path", self.model.cwd
+        )
         self.model.cwd = os.path.dirname(path)
         if path:
             self.model.trainPath = path
 
     def setMTestPath(self):
-        path = QFileDialog.getExistingDirectory(self.mainView, "Choose Test Set Path", self.model.cwd)
+        path = QFileDialog.getExistingDirectory(
+            self.mainView, "Choose Test Set Path", self.model.cwd
+        )
         self.model.cwd = os.path.dirname(path)
         if path:
             self.model.testPath = path
 
+    def setMValidationPath(self):
+        path = QFileDialog.getExistingDirectory(
+            self.mainView, "Choose Validation Set Path", self.model.cwd
+        )
+        self.model.cwd = os.path.dirname(path)
+        if path:
+            self.model.validationPath = path
+
     def setMCheckPointPath(self):
-        path = QFileDialog.getExistingDirectory(self.mainView, "Choose Checkpoints Path", self.model.cwd)
+        path = QFileDialog.getExistingDirectory(
+            self.mainView, "Choose Checkpoints Path", self.model.cwd
+        )
         self.model.cwd = os.path.dirname(path)
         if path:
             self.model.checkPointPath = path
@@ -72,7 +89,9 @@ class MainController(QObject):
         self.initWeightFiles()
 
     def setMInfluencePath(self):
-        path = QFileDialog.getExistingDirectory(self.mainView, "Choose Influence Result Path", self.model.cwd)
+        path = QFileDialog.getExistingDirectory(
+            self.mainView, "Choose Influence Result Path", self.model.cwd
+        )
         self.model.cwd = os.path.dirname(path)
         if path:
             self.model.influencePath = path
@@ -82,9 +101,9 @@ class MainController(QObject):
 
     def setMPretrained(self):
         if self.mainView.ui.pretrainedCheckBox.isChecked():
-            self.model.pretrained = 'True'
+            self.model.pretrained = "True"
         else:
-            self.model.pretrained = 'False'
+            self.model.pretrained = "False"
 
     def setMWeightFile(self):
         self.model.weightFile = self.mainView.ui.weightFileComboBox.currentText()
@@ -94,9 +113,9 @@ class MainController(QObject):
 
     def setMShuffle(self):
         if self.mainView.ui.shuffleCheckBox.isChecked():
-            self.model.shuffle = 'True'
+            self.model.shuffle = "True"
         else:
-            self.model.shuffle = 'False'
+            self.model.shuffle = "False"
 
     def setMBatchSize(self):
         self.model.batchSize = self.mainView.ui.batchSizeInput.text()
@@ -114,25 +133,35 @@ class MainController(QObject):
         self.model.classNumber = self.mainView.ui.classNumberInput.text()
 
     def loadProfile(self):
-        path, _ = QFileDialog.getOpenFileName(self.mainView, "Load Profile", self.model.cwd, "JSON Files (*.json);;All Files (*)")
+        path, _ = QFileDialog.getOpenFileName(
+            self.mainView,
+            "Load Profile",
+            self.model.cwd,
+            "JSON Files (*.json);;All Files (*)",
+        )
         self.model.cwd = os.path.dirname(path)
         try:
-            with open(path, 'r') as f:
+            with open(path, "r") as f:
                 self.model.profile = json.load(f)
         except FileNotFoundError:
-            print('Load path not found')
+            print("Load path not found")
 
     def saveProfile(self):
-        path, _ = QFileDialog.getSaveFileName(self.mainView, "Save Profile", self.model.cwd, "JSON Files (*.json);;All Files (*)")
+        path, _ = QFileDialog.getSaveFileName(
+            self.mainView,
+            "Save Profile",
+            self.model.cwd,
+            "JSON Files (*.json);;All Files (*)",
+        )
         self.model.cwd = os.path.dirname(path)
         try:
-            with open(path, 'w') as f:
+            with open(path, "w") as f:
                 json.dump(self.model.profile, f)
         except FileNotFoundError:
-            print('The dialog is closed')
+            print("The dialog is closed")
 
     def startServer(self):
-        if(self.mainView.ui.tabWidget.currentIndex() == 0 and self.checkProfile()):
+        if self.mainView.ui.tabWidget.currentIndex() == 0 and self.checkProfile():
             return
         else:
             t = ServerOperationThread(target=self.dockerCtrl.startServer, ctrl=self)
@@ -149,7 +178,6 @@ class MainController(QObject):
     def refreshServers(self):
         t = Thread(target=self.dockerCtrl.refreshServers)
         t.start()
-
 
     # Slot functions to change the view
     def setVContainerName(self, val):
@@ -178,7 +206,7 @@ class MainController(QObject):
         self.mainView.ui.archComboBox.setCurrentText(val)
 
     def setVPretrained(self, val):
-        if val == 'True':
+        if val == "True":
             self.mainView.ui.pretrainedCheckBox.setChecked(True)
         else:
             self.mainView.ui.pretrainedCheckBox.setChecked(False)
@@ -190,7 +218,7 @@ class MainController(QObject):
         self.mainView.ui.deviceInput.setText(val)
 
     def setVShuffle(self, val):
-        if val == 'True':
+        if val == "True":
             self.mainView.ui.shuffleCheckBox.setChecked(True)
         else:
             self.mainView.ui.shuffleCheckBox.setChecked(False)
@@ -210,14 +238,15 @@ class MainController(QObject):
     def setVClassNumber(self, val):
         self.mainView.ui.classNumberInput.setText(val)
 
-
     # Other control functions
     def printMessage(self, textBrowser, message, timestamp=True):
-        if(timestamp == True):
+        if timestamp == True:
             currentTime = time.strftime("%H:%M:%S", time.localtime())
-            message = currentTime + ' - - ' + message + '\n'
+            message = currentTime + " - - " + message + "\n"
         textBrowser.append(message)
-        textBrowser.verticalScrollBar().setValue(textBrowser.verticalScrollBar().maximum())
+        textBrowser.verticalScrollBar().setValue(
+            textBrowser.verticalScrollBar().maximum()
+        )
 
     def addItem(self, listWidget, name):
         listWidget.addItem(name)
@@ -239,61 +268,86 @@ class MainController(QObject):
         self.mainView.ui.deleteServerButton.setEnabled(False)
 
     def checkProfile(self):
-        missProfileDict = {'trainPath': 'train set path', 'testPath': 'test set path',
-                          'influencePath': 'influence result path', 'checkPointPath': 'check point path',
-                           'batch_size': 'batch size', 'num_workers': 'worker number',
-                           'num_classes': 'class number', 'image_size': 'image size'}
+        missProfileDict = {
+            "trainPath": "train set path",
+            "testPath": "test set path",
+            "influencePath": "influence result path",
+            "checkPointPath": "check point path",
+            "batch_size": "batch size",
+            "num_workers": "worker number",
+            "num_classes": "class number",
+            "image_size": "image size",
+        }
         missProfilePrompt = []
 
-        for profileName in ['trainPath', 'testPath', 'influencePath', 'checkPointPath', 'batch_size', 'num_workers', 'num_classes', 'image_size']:
+        for profileName in [
+            "trainPath",
+            "testPath",
+            "influencePath",
+            "checkPointPath",
+            "batch_size",
+            "num_workers",
+            "num_classes",
+            "image_size",
+        ]:
             if not self.model.profile[profileName].strip():
                 missProfilePrompt.append(missProfileDict[profileName])
 
         if len(missProfilePrompt) != 0:
-            self.printMessage(self.mainView.ui.promptBrowser,
-                              "Please provide {}".format(', '.join(missProfilePrompt)))
+            self.printMessage(
+                self.mainView.ui.promptBrowser,
+                "Please provide {}".format(", ".join(missProfilePrompt)),
+            )
             return 1
         return 0
-    
-    def getItemsFromListWidgets(self):
-        return self.mainView.ui.runningListWidget.selectedItems() if len(
-            self.mainView.ui.runningListWidget.selectedItems()) > 0 else self.mainView.ui.exitedListWidget.selectedItems() if len(
-            self.mainView.ui.exitedListWidget.selectedItems()) > 0 else self.mainView.ui.createdListWidget.selectedItems() if len(
-            self.mainView.ui.createdListWidget.selectedItems()) > 0 else []
 
+    def getItemsFromListWidgets(self):
+        return (
+            self.mainView.ui.runningListWidget.selectedItems()
+            if len(self.mainView.ui.runningListWidget.selectedItems()) > 0
+            else self.mainView.ui.exitedListWidget.selectedItems()
+            if len(self.mainView.ui.exitedListWidget.selectedItems()) > 0
+            else self.mainView.ui.createdListWidget.selectedItems()
+            if len(self.mainView.ui.createdListWidget.selectedItems()) > 0
+            else []
+        )
 
     def updateSucView(self):
-        with open('./RecordData/config_record.json', 'r') as f:
+        with open("./RecordData/config_record.json", "r") as f:
             matchDict = json.load(f)
             fileName = matchDict[self.model.tempName]
         with open(fileName) as f:
             config = json.load(f)
-            port = config['port']
+            port = config["port"]
 
-        self.printMessage(self.mainView.ui.promptBrowser,
-                                    '{} is available at http://localhost:{}'.format(self.model.tempName,
-                                                                                    port))
+        self.printMessage(
+            self.mainView.ui.promptBrowser,
+            "{} is available at http://localhost:{}".format(self.model.tempName, port),
+        )
         self.addItem(self.mainView.ui.runningListWidget, self.model.tempName)
 
     # Fetch the docker image versions to add to the image version combobox and initiate model's image version
     def initImageVersions(self):
         res = requests.get(
-            'https://registry.hub.docker.com/v2/repositories/paulcccccch/robustar/tags?page_size=1024', timeout=3)
+            "https://registry.hub.docker.com/v2/repositories/paulcccccch/robustar/tags?page_size=1024",
+            timeout=3,
+        )
 
-        for item in res.json()['results']:
-            self.mainView.ui.versionComboBox.addItem(item['name'])
+        for item in res.json()["results"]:
+            self.mainView.ui.versionComboBox.addItem(item["name"])
         self.model.imageVersion = self.mainView.ui.versionComboBox.currentText()
 
     # Scan the checkpoint directory to add checkpoint files to the weight file combobox and initiates model's weight file
     def initWeightFiles(self):
         self.mainView.ui.weightFileComboBox.clear()
-        self.mainView.ui.weightFileComboBox.addItem('None')
+        self.mainView.ui.weightFileComboBox.addItem("None")
 
         for file in os.listdir(self.model.checkPointPath):
-            if file.endswith('.pth') or file.endswith('.pt'):
+            if file.endswith(".pth") or file.endswith(".pt"):
                 self.mainView.ui.weightFileComboBox.addItem(file)
 
         self.model.weightFile = self.mainView.ui.weightFileComboBox.currentText()
+
 
 class ServerOperationThread(Thread):
     def __init__(self, target, ctrl):

--- a/launcher/resources/launcher_v2.ui
+++ b/launcher/resources/launcher_v2.ui
@@ -1044,6 +1044,118 @@ QPushButton:hover {
                       </layout>
                      </item>
                      <item>
+                      <layout class="QHBoxLayout" name="horizontalLayout_validation_set">
+                       <property name="rightMargin">
+                        <number>0</number>
+                       </property>
+                       <item>
+                        <widget class="QLabel" name="label_validation_set">
+                         <property name="sizePolicy">
+                          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                           <horstretch>0</horstretch>
+                           <verstretch>0</verstretch>
+                          </sizepolicy>
+                         </property>
+                         <property name="minimumSize">
+                          <size>
+                           <width>174</width>
+                           <height>39</height>
+                          </size>
+                         </property>
+                         <property name="maximumSize">
+                          <size>
+                           <width>174</width>
+                           <height>39</height>
+                          </size>
+                         </property>
+                         <property name="font">
+                          <font>
+                           <family>Arial</family>
+                           <pointsize>8</pointsize>
+                           <weight>50</weight>
+                           <italic>false</italic>
+                           <bold>false</bold>
+                          </font>
+                         </property>
+                         <property name="toolTip">
+                          <string>The root path of the validation set</string>
+                         </property>
+                         <property name="text">
+                          <string>Validation Set</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QLineEdit" name="validationPathDisplay">
+                         <property name="sizePolicy">
+                          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                           <horstretch>0</horstretch>
+                           <verstretch>0</verstretch>
+                          </sizepolicy>
+                         </property>
+                         <property name="minimumSize">
+                          <size>
+                           <width>137</width>
+                           <height>24</height>
+                          </size>
+                         </property>
+                         <property name="maximumSize">
+                          <size>
+                           <width>137</width>
+                           <height>24</height>
+                          </size>
+                         </property>
+                         <property name="font">
+                          <font>
+                           <family>Arial</family>
+                           <pointsize>8</pointsize>
+                           <weight>50</weight>
+                           <italic>false</italic>
+                           <bold>false</bold>
+                          </font>
+                         </property>
+                         <property name="text">
+                          <string/>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QPushButton" name="validationPathButton">
+                         <property name="sizePolicy">
+                          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                           <horstretch>0</horstretch>
+                           <verstretch>0</verstretch>
+                          </sizepolicy>
+                         </property>
+                         <property name="minimumSize">
+                          <size>
+                           <width>28</width>
+                           <height>20</height>
+                          </size>
+                         </property>
+                         <property name="maximumSize">
+                          <size>
+                           <width>28</width>
+                           <height>20</height>
+                          </size>
+                         </property>
+                         <property name="font">
+                          <font>
+                           <family>Arial</family>
+                           <pointsize>8</pointsize>
+                           <weight>50</weight>
+                           <italic>false</italic>
+                           <bold>false</bold>
+                          </font>
+                         </property>
+                         <property name="text">
+                          <string>...</string>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </item>
+                     <item>
                       <layout class="QHBoxLayout" name="horizontalLayout_17">
                        <property name="rightMargin">
                         <number>0</number>

--- a/launcher/views/main_view.py
+++ b/launcher/views/main_view.py
@@ -16,6 +16,7 @@ class MainView(QWidget):
         self.ui.portInput.textEdited.connect(self.ctrl.setMPort)
         self.ui.trainPathButton.clicked.connect(self.ctrl.setMTrainPath)
         self.ui.testPathButton.clicked.connect(self.ctrl.setMTestPath)
+        self.ui.validationPathButton.clicked.connect(self.ctrl.setMValidationPath)
         self.ui.checkPointPathButton.clicked.connect(self.ctrl.setMCheckPointPath)
         self.ui.influencePathButton.clicked.connect(self.ctrl.setMInfluencePath)
 
@@ -38,14 +39,26 @@ class MainView(QWidget):
         self.ui.refreshListWidgetsButton.clicked.connect(self.ctrl.refreshServers)
 
         # Set the listWidgets so that only one entry in them can be selected at a time
-        self.listWidgets = [self.ui.runningListWidget, self.ui.exitedListWidget, self.ui.createdListWidget]
+        self.listWidgets = [
+            self.ui.runningListWidget,
+            self.ui.exitedListWidget,
+            self.ui.createdListWidget,
+        ]
         self.ui.runningListWidget.selectionModel().selectionChanged.connect(
-            lambda sel, unsel: self.singleSelect(self.ui.runningListWidget, self.listWidgets))
+            lambda sel, unsel: self.singleSelect(
+                self.ui.runningListWidget, self.listWidgets
+            )
+        )
         self.ui.exitedListWidget.selectionModel().selectionChanged.connect(
-            lambda sel, unsel: self.singleSelect(self.ui.exitedListWidget, self.listWidgets))
+            lambda sel, unsel: self.singleSelect(
+                self.ui.exitedListWidget, self.listWidgets
+            )
+        )
         self.ui.createdListWidget.selectionModel().selectionChanged.connect(
-            lambda sel, unsel: self.singleSelect(self.ui.createdListWidget, self.listWidgets))
-
+            lambda sel, unsel: self.singleSelect(
+                self.ui.createdListWidget, self.listWidgets
+            )
+        )
 
     # Function to ensure only one entry in the three listWidgets can be selected at a time
     def singleSelect(self, listWidget, listWidgets):

--- a/launcher/views/main_view_ui.py
+++ b/launcher/views/main_view_ui.py
@@ -14,10 +14,11 @@ from PySide2.QtWidgets import *
 
 import resource_rc
 
+
 class Ui_RobustarLauncher(object):
     def setupUi(self, RobustarLauncher):
         if not RobustarLauncher.objectName():
-            RobustarLauncher.setObjectName(u"RobustarLauncher")
+            RobustarLauncher.setObjectName("RobustarLauncher")
         RobustarLauncher.resize(1000, 1020)
         sizePolicy = QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
         sizePolicy.setHorizontalStretch(0)
@@ -27,33 +28,35 @@ class Ui_RobustarLauncher(object):
         RobustarLauncher.setMinimumSize(QSize(1000, 1020))
         RobustarLauncher.setMaximumSize(QSize(1000, 1020))
         font = QFont()
-        font.setFamily(u"Arial")
+        font.setFamily("Arial")
         font.setPointSize(8)
         font.setBold(False)
         font.setItalic(False)
         font.setWeight(50)
         RobustarLauncher.setFont(font)
         icon = QIcon()
-        icon.addFile(u":/resources/logo_short.png", QSize(), QIcon.Normal, QIcon.Off)
+        icon.addFile(":/resources/logo_short.png", QSize(), QIcon.Normal, QIcon.Off)
         RobustarLauncher.setWindowIcon(icon)
-        RobustarLauncher.setStyleSheet(u"QWidget{font: 8pt \"Arial\"}\n"
-"QPushButton{background-color: #E1E1E1; \n"
-"			font: 8pt Arial;\n"
-"			border: 1px solid #ADADAD;}\n"
-"QPushButton:hover {\n"
-"   background-color: #E3ECF3;\n"
-"   border: 1px solid #3287CA;\n"
-"}")
+        RobustarLauncher.setStyleSheet(
+            'QWidget{font: 8pt "Arial"}\n'
+            "QPushButton{background-color: #E1E1E1; \n"
+            "			font: 8pt Arial;\n"
+            "			border: 1px solid #ADADAD;}\n"
+            "QPushButton:hover {\n"
+            "   background-color: #E3ECF3;\n"
+            "   border: 1px solid #3287CA;\n"
+            "}"
+        )
         self.layoutWidget = QWidget(RobustarLauncher)
-        self.layoutWidget.setObjectName(u"layoutWidget")
+        self.layoutWidget.setObjectName("layoutWidget")
         self.layoutWidget.setGeometry(QRect(0, 0, 1001, 1001))
         self.verticalLayout = QVBoxLayout(self.layoutWidget)
-        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.verticalLayout.setObjectName("verticalLayout")
         self.verticalLayout.setContentsMargins(0, 0, 0, 0)
         self.headerLayout = QHBoxLayout()
-        self.headerLayout.setObjectName(u"headerLayout")
+        self.headerLayout.setObjectName("headerLayout")
         self.header = QLabel(self.layoutWidget)
-        self.header.setObjectName(u"header")
+        self.header.setObjectName("header")
         sizePolicy1 = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         sizePolicy1.setHorizontalStretch(0)
         sizePolicy1.setVerticalStretch(0)
@@ -62,71 +65,78 @@ class Ui_RobustarLauncher(object):
         self.header.setMinimumSize(QSize(164, 42))
         self.header.setMaximumSize(QSize(164, 42))
         self.header.setTextFormat(Qt.AutoText)
-        self.header.setPixmap(QPixmap(u":/resources/logo_long.png"))
+        self.header.setPixmap(QPixmap(":/resources/logo_long.png"))
         self.header.setScaledContents(True)
         self.header.setIndent(-1)
 
         self.headerLayout.addWidget(self.header)
 
-
         self.verticalLayout.addLayout(self.headerLayout)
 
         self.horizontalLayout_2 = QHBoxLayout()
-        self.horizontalLayout_2.setObjectName(u"horizontalLayout_2")
+        self.horizontalLayout_2.setObjectName("horizontalLayout_2")
         self.horizontalLayout_2.setContentsMargins(15, -1, 11, -1)
         self.buttonFrame = QFrame(self.layoutWidget)
-        self.buttonFrame.setObjectName(u"buttonFrame")
+        self.buttonFrame.setObjectName("buttonFrame")
         sizePolicy1.setHeightForWidth(self.buttonFrame.sizePolicy().hasHeightForWidth())
         self.buttonFrame.setSizePolicy(sizePolicy1)
         self.buttonFrame.setMinimumSize(QSize(161, 905))
         self.buttonFrame.setMaximumSize(QSize(161, 905))
         self.buttonFrame.setFont(font)
-        self.buttonFrame.setStyleSheet(u"#buttonFrame{background: #F9F9F9}\n"
-"")
+        self.buttonFrame.setStyleSheet("#buttonFrame{background: #F9F9F9}\n" "")
         self.buttonFrame.setFrameShape(QFrame.StyledPanel)
         self.buttonFrame.setFrameShadow(QFrame.Raised)
         self.layoutWidget1 = QWidget(self.buttonFrame)
-        self.layoutWidget1.setObjectName(u"layoutWidget1")
+        self.layoutWidget1.setObjectName("layoutWidget1")
         self.layoutWidget1.setGeometry(QRect(0, 0, 161, 901))
         self.buttonLayout = QVBoxLayout(self.layoutWidget1)
         self.buttonLayout.setSpacing(60)
-        self.buttonLayout.setObjectName(u"buttonLayout")
+        self.buttonLayout.setObjectName("buttonLayout")
         self.buttonLayout.setSizeConstraint(QLayout.SetDefaultConstraint)
         self.buttonLayout.setContentsMargins(0, 60, 0, 0)
         self.loadButtonLayout = QHBoxLayout()
-        self.loadButtonLayout.setObjectName(u"loadButtonLayout")
+        self.loadButtonLayout.setObjectName("loadButtonLayout")
         self.loadButtonLayout.setContentsMargins(-1, 0, -1, -1)
-        self.horizontalSpacer_9 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.horizontalSpacer_9 = QSpacerItem(
+            40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum
+        )
 
         self.loadButtonLayout.addItem(self.horizontalSpacer_9)
 
         self.loadProfileButton = QPushButton(self.layoutWidget1)
-        self.loadProfileButton.setObjectName(u"loadProfileButton")
-        sizePolicy1.setHeightForWidth(self.loadProfileButton.sizePolicy().hasHeightForWidth())
+        self.loadProfileButton.setObjectName("loadProfileButton")
+        sizePolicy1.setHeightForWidth(
+            self.loadProfileButton.sizePolicy().hasHeightForWidth()
+        )
         self.loadProfileButton.setSizePolicy(sizePolicy1)
         self.loadProfileButton.setMinimumSize(QSize(100, 25))
         self.loadProfileButton.setMaximumSize(QSize(100, 25))
         self.loadProfileButton.setFont(font)
-        self.loadProfileButton.setStyleSheet(u"")
+        self.loadProfileButton.setStyleSheet("")
 
         self.loadButtonLayout.addWidget(self.loadProfileButton)
 
-        self.horizontalSpacer_10 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.horizontalSpacer_10 = QSpacerItem(
+            40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum
+        )
 
         self.loadButtonLayout.addItem(self.horizontalSpacer_10)
-
 
         self.buttonLayout.addLayout(self.loadButtonLayout)
 
         self.saveButtonLayout = QHBoxLayout()
-        self.saveButtonLayout.setObjectName(u"saveButtonLayout")
-        self.horizontalSpacer_7 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.saveButtonLayout.setObjectName("saveButtonLayout")
+        self.horizontalSpacer_7 = QSpacerItem(
+            40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum
+        )
 
         self.saveButtonLayout.addItem(self.horizontalSpacer_7)
 
         self.saveProfileButton = QPushButton(self.layoutWidget1)
-        self.saveProfileButton.setObjectName(u"saveProfileButton")
-        sizePolicy1.setHeightForWidth(self.saveProfileButton.sizePolicy().hasHeightForWidth())
+        self.saveProfileButton.setObjectName("saveProfileButton")
+        sizePolicy1.setHeightForWidth(
+            self.saveProfileButton.sizePolicy().hasHeightForWidth()
+        )
         self.saveProfileButton.setSizePolicy(sizePolicy1)
         self.saveProfileButton.setMinimumSize(QSize(100, 25))
         self.saveProfileButton.setMaximumSize(QSize(100, 25))
@@ -134,22 +144,27 @@ class Ui_RobustarLauncher(object):
 
         self.saveButtonLayout.addWidget(self.saveProfileButton)
 
-        self.horizontalSpacer_8 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.horizontalSpacer_8 = QSpacerItem(
+            40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum
+        )
 
         self.saveButtonLayout.addItem(self.horizontalSpacer_8)
-
 
         self.buttonLayout.addLayout(self.saveButtonLayout)
 
         self.startButtonLayout = QHBoxLayout()
-        self.startButtonLayout.setObjectName(u"startButtonLayout")
-        self.horizontalSpacer_5 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.startButtonLayout.setObjectName("startButtonLayout")
+        self.horizontalSpacer_5 = QSpacerItem(
+            40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum
+        )
 
         self.startButtonLayout.addItem(self.horizontalSpacer_5)
 
         self.startServerButton = QPushButton(self.layoutWidget1)
-        self.startServerButton.setObjectName(u"startServerButton")
-        sizePolicy1.setHeightForWidth(self.startServerButton.sizePolicy().hasHeightForWidth())
+        self.startServerButton.setObjectName("startServerButton")
+        sizePolicy1.setHeightForWidth(
+            self.startServerButton.sizePolicy().hasHeightForWidth()
+        )
         self.startServerButton.setSizePolicy(sizePolicy1)
         self.startServerButton.setMinimumSize(QSize(100, 25))
         self.startServerButton.setMaximumSize(QSize(100, 25))
@@ -158,22 +173,27 @@ class Ui_RobustarLauncher(object):
 
         self.startButtonLayout.addWidget(self.startServerButton)
 
-        self.horizontalSpacer_6 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.horizontalSpacer_6 = QSpacerItem(
+            40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum
+        )
 
         self.startButtonLayout.addItem(self.horizontalSpacer_6)
-
 
         self.buttonLayout.addLayout(self.startButtonLayout)
 
         self.stopButtoLayout = QHBoxLayout()
-        self.stopButtoLayout.setObjectName(u"stopButtoLayout")
-        self.horizontalSpacer_3 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.stopButtoLayout.setObjectName("stopButtoLayout")
+        self.horizontalSpacer_3 = QSpacerItem(
+            40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum
+        )
 
         self.stopButtoLayout.addItem(self.horizontalSpacer_3)
 
         self.stopServerButton = QPushButton(self.layoutWidget1)
-        self.stopServerButton.setObjectName(u"stopServerButton")
-        sizePolicy1.setHeightForWidth(self.stopServerButton.sizePolicy().hasHeightForWidth())
+        self.stopServerButton.setObjectName("stopServerButton")
+        sizePolicy1.setHeightForWidth(
+            self.stopServerButton.sizePolicy().hasHeightForWidth()
+        )
         self.stopServerButton.setSizePolicy(sizePolicy1)
         self.stopServerButton.setMinimumSize(QSize(100, 25))
         self.stopServerButton.setMaximumSize(QSize(100, 25))
@@ -181,22 +201,27 @@ class Ui_RobustarLauncher(object):
 
         self.stopButtoLayout.addWidget(self.stopServerButton)
 
-        self.horizontalSpacer_4 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.horizontalSpacer_4 = QSpacerItem(
+            40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum
+        )
 
         self.stopButtoLayout.addItem(self.horizontalSpacer_4)
-
 
         self.buttonLayout.addLayout(self.stopButtoLayout)
 
         self.deleteButtonLayout = QHBoxLayout()
-        self.deleteButtonLayout.setObjectName(u"deleteButtonLayout")
-        self.horizontalSpacer = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.deleteButtonLayout.setObjectName("deleteButtonLayout")
+        self.horizontalSpacer = QSpacerItem(
+            40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum
+        )
 
         self.deleteButtonLayout.addItem(self.horizontalSpacer)
 
         self.deleteServerButton = QPushButton(self.layoutWidget1)
-        self.deleteServerButton.setObjectName(u"deleteServerButton")
-        sizePolicy1.setHeightForWidth(self.deleteServerButton.sizePolicy().hasHeightForWidth())
+        self.deleteServerButton.setObjectName("deleteServerButton")
+        sizePolicy1.setHeightForWidth(
+            self.deleteServerButton.sizePolicy().hasHeightForWidth()
+        )
         self.deleteServerButton.setSizePolicy(sizePolicy1)
         self.deleteServerButton.setMinimumSize(QSize(100, 25))
         self.deleteServerButton.setMaximumSize(QSize(100, 25))
@@ -204,14 +229,17 @@ class Ui_RobustarLauncher(object):
 
         self.deleteButtonLayout.addWidget(self.deleteServerButton)
 
-        self.horizontalSpacer_2 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.horizontalSpacer_2 = QSpacerItem(
+            40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum
+        )
 
         self.deleteButtonLayout.addItem(self.horizontalSpacer_2)
 
-
         self.buttonLayout.addLayout(self.deleteButtonLayout)
 
-        self.verticalSpacer_2 = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.MinimumExpanding)
+        self.verticalSpacer_2 = QSpacerItem(
+            20, 40, QSizePolicy.Minimum, QSizePolicy.MinimumExpanding
+        )
 
         self.buttonLayout.addItem(self.verticalSpacer_2)
 
@@ -225,47 +253,49 @@ class Ui_RobustarLauncher(object):
         self.horizontalLayout_2.addWidget(self.buttonFrame)
 
         self.verticalLayout_2 = QVBoxLayout()
-        self.verticalLayout_2.setObjectName(u"verticalLayout_2")
+        self.verticalLayout_2.setObjectName("verticalLayout_2")
         self.verticalLayout_2.setContentsMargins(-1, 0, -1, 0)
         self.tabWidget = QTabWidget(self.layoutWidget)
-        self.tabWidget.setObjectName(u"tabWidget")
+        self.tabWidget.setObjectName("tabWidget")
         sizePolicy1.setHeightForWidth(self.tabWidget.sizePolicy().hasHeightForWidth())
         self.tabWidget.setSizePolicy(sizePolicy1)
         self.tabWidget.setMinimumSize(QSize(801, 575))
         self.tabWidget.setMaximumSize(QSize(801, 575))
         self.tabWidget.setFont(font)
         self.createTab = QWidget()
-        self.createTab.setObjectName(u"createTab")
+        self.createTab.setObjectName("createTab")
         self.horizontalLayoutWidget_7 = QWidget(self.createTab)
-        self.horizontalLayoutWidget_7.setObjectName(u"horizontalLayoutWidget_7")
+        self.horizontalLayoutWidget_7.setObjectName("horizontalLayoutWidget_7")
         self.horizontalLayoutWidget_7.setGeometry(QRect(20, 10, 761, 531))
         self.horizontalLayout_6 = QHBoxLayout(self.horizontalLayoutWidget_7)
-        self.horizontalLayout_6.setObjectName(u"horizontalLayout_6")
+        self.horizontalLayout_6.setObjectName("horizontalLayout_6")
         self.horizontalLayout_6.setContentsMargins(0, 0, 0, 0)
         self.horizontalLayout_3 = QHBoxLayout()
         self.horizontalLayout_3.setSpacing(9)
-        self.horizontalLayout_3.setObjectName(u"horizontalLayout_3")
+        self.horizontalLayout_3.setObjectName("horizontalLayout_3")
         self.verticalLayout_3 = QVBoxLayout()
         self.verticalLayout_3.setSpacing(0)
-        self.verticalLayout_3.setObjectName(u"verticalLayout_3")
+        self.verticalLayout_3.setObjectName("verticalLayout_3")
         self.verticalLayout_3.setContentsMargins(-1, 0, -1, -1)
         self.dockerGroupBox = QGroupBox(self.horizontalLayoutWidget_7)
-        self.dockerGroupBox.setObjectName(u"dockerGroupBox")
-        sizePolicy.setHeightForWidth(self.dockerGroupBox.sizePolicy().hasHeightForWidth())
+        self.dockerGroupBox.setObjectName("dockerGroupBox")
+        sizePolicy.setHeightForWidth(
+            self.dockerGroupBox.sizePolicy().hasHeightForWidth()
+        )
         self.dockerGroupBox.setSizePolicy(sizePolicy)
         self.dockerGroupBox.setMinimumSize(QSize(0, 169))
         self.dockerGroupBox.setMaximumSize(QSize(16777215, 168))
         self.dockerGroupBox.setFont(font)
         self.layoutWidget2 = QWidget(self.dockerGroupBox)
-        self.layoutWidget2.setObjectName(u"layoutWidget2")
+        self.layoutWidget2.setObjectName("layoutWidget2")
         self.layoutWidget2.setGeometry(QRect(10, 20, 362, 143))
         self.verticalLayout_6 = QVBoxLayout(self.layoutWidget2)
-        self.verticalLayout_6.setObjectName(u"verticalLayout_6")
+        self.verticalLayout_6.setObjectName("verticalLayout_6")
         self.verticalLayout_6.setContentsMargins(0, 0, 0, 0)
         self.horizontalLayout_8 = QHBoxLayout()
-        self.horizontalLayout_8.setObjectName(u"horizontalLayout_8")
+        self.horizontalLayout_8.setObjectName("horizontalLayout_8")
         self.label_8 = QLabel(self.layoutWidget2)
-        self.label_8.setObjectName(u"label_8")
+        self.label_8.setObjectName("label_8")
         sizePolicy1.setHeightForWidth(self.label_8.sizePolicy().hasHeightForWidth())
         self.label_8.setSizePolicy(sizePolicy1)
         self.label_8.setMinimumSize(QSize(174, 39))
@@ -275,24 +305,23 @@ class Ui_RobustarLauncher(object):
         self.horizontalLayout_8.addWidget(self.label_8)
 
         self.nameInput = QLineEdit(self.layoutWidget2)
-        self.nameInput.setObjectName(u"nameInput")
+        self.nameInput.setObjectName("nameInput")
         sizePolicy1.setHeightForWidth(self.nameInput.sizePolicy().hasHeightForWidth())
         self.nameInput.setSizePolicy(sizePolicy1)
         self.nameInput.setMinimumSize(QSize(174, 24))
         self.nameInput.setMaximumSize(QSize(174, 24))
         self.nameInput.setFont(font)
-        self.nameInput.setAlignment(Qt.AlignLeading|Qt.AlignLeft|Qt.AlignVCenter)
+        self.nameInput.setAlignment(Qt.AlignLeading | Qt.AlignLeft | Qt.AlignVCenter)
         self.nameInput.setClearButtonEnabled(True)
 
         self.horizontalLayout_8.addWidget(self.nameInput)
 
-
         self.verticalLayout_6.addLayout(self.horizontalLayout_8)
 
         self.horizontalLayout_5 = QHBoxLayout()
-        self.horizontalLayout_5.setObjectName(u"horizontalLayout_5")
+        self.horizontalLayout_5.setObjectName("horizontalLayout_5")
         self.label_3 = QLabel(self.layoutWidget2)
-        self.label_3.setObjectName(u"label_3")
+        self.label_3.setObjectName("label_3")
         sizePolicy1.setHeightForWidth(self.label_3.sizePolicy().hasHeightForWidth())
         self.label_3.setSizePolicy(sizePolicy1)
         self.label_3.setMinimumSize(QSize(174, 39))
@@ -302,8 +331,10 @@ class Ui_RobustarLauncher(object):
         self.horizontalLayout_5.addWidget(self.label_3)
 
         self.versionComboBox = QComboBox(self.layoutWidget2)
-        self.versionComboBox.setObjectName(u"versionComboBox")
-        sizePolicy1.setHeightForWidth(self.versionComboBox.sizePolicy().hasHeightForWidth())
+        self.versionComboBox.setObjectName("versionComboBox")
+        sizePolicy1.setHeightForWidth(
+            self.versionComboBox.sizePolicy().hasHeightForWidth()
+        )
         self.versionComboBox.setSizePolicy(sizePolicy1)
         self.versionComboBox.setMinimumSize(QSize(174, 24))
         self.versionComboBox.setMaximumSize(QSize(174, 24))
@@ -311,13 +342,12 @@ class Ui_RobustarLauncher(object):
 
         self.horizontalLayout_5.addWidget(self.versionComboBox)
 
-
         self.verticalLayout_6.addLayout(self.horizontalLayout_5)
 
         self.horizontalLayout_9 = QHBoxLayout()
-        self.horizontalLayout_9.setObjectName(u"horizontalLayout_9")
+        self.horizontalLayout_9.setObjectName("horizontalLayout_9")
         self.label_7 = QLabel(self.layoutWidget2)
-        self.label_7.setObjectName(u"label_7")
+        self.label_7.setObjectName("label_7")
         sizePolicy1.setHeightForWidth(self.label_7.sizePolicy().hasHeightForWidth())
         self.label_7.setSizePolicy(sizePolicy1)
         self.label_7.setMinimumSize(QSize(174, 39))
@@ -327,44 +357,44 @@ class Ui_RobustarLauncher(object):
         self.horizontalLayout_9.addWidget(self.label_7)
 
         self.portInput = QLineEdit(self.layoutWidget2)
-        self.portInput.setObjectName(u"portInput")
+        self.portInput.setObjectName("portInput")
         sizePolicy1.setHeightForWidth(self.portInput.sizePolicy().hasHeightForWidth())
         self.portInput.setSizePolicy(sizePolicy1)
         self.portInput.setMinimumSize(QSize(174, 24))
         self.portInput.setMaximumSize(QSize(174, 24))
         self.portInput.setFont(font)
-        self.portInput.setAlignment(Qt.AlignLeading|Qt.AlignLeft|Qt.AlignVCenter)
+        self.portInput.setAlignment(Qt.AlignLeading | Qt.AlignLeft | Qt.AlignVCenter)
         self.portInput.setClearButtonEnabled(True)
 
         self.horizontalLayout_9.addWidget(self.portInput)
 
-
         self.verticalLayout_6.addLayout(self.horizontalLayout_9)
-
 
         self.verticalLayout_3.addWidget(self.dockerGroupBox)
 
-        self.verticalSpacer = QSpacerItem(20, 132, QSizePolicy.Minimum, QSizePolicy.Maximum)
+        self.verticalSpacer = QSpacerItem(
+            20, 132, QSizePolicy.Minimum, QSizePolicy.Maximum
+        )
 
         self.verticalLayout_3.addItem(self.verticalSpacer)
 
         self.dataGroupBox = QGroupBox(self.horizontalLayoutWidget_7)
-        self.dataGroupBox.setObjectName(u"dataGroupBox")
+        self.dataGroupBox.setObjectName("dataGroupBox")
         self.dataGroupBox.setMinimumSize(QSize(0, 0))
         self.dataGroupBox.setMaximumSize(QSize(16777215, 232))
         self.dataGroupBox.setFont(font)
         self.layoutWidget3 = QWidget(self.dataGroupBox)
-        self.layoutWidget3.setObjectName(u"layoutWidget3")
+        self.layoutWidget3.setObjectName("layoutWidget3")
         self.layoutWidget3.setGeometry(QRect(10, 20, 361, 193))
         self.verticalLayout_7 = QVBoxLayout(self.layoutWidget3)
         self.verticalLayout_7.setSpacing(9)
-        self.verticalLayout_7.setObjectName(u"verticalLayout_7")
+        self.verticalLayout_7.setObjectName("verticalLayout_7")
         self.verticalLayout_7.setContentsMargins(0, 0, 0, 0)
         self.horizontalLayout_16 = QHBoxLayout()
-        self.horizontalLayout_16.setObjectName(u"horizontalLayout_16")
+        self.horizontalLayout_16.setObjectName("horizontalLayout_16")
         self.horizontalLayout_16.setContentsMargins(0, -1, -1, -1)
         self.label_6 = QLabel(self.layoutWidget3)
-        self.label_6.setObjectName(u"label_6")
+        self.label_6.setObjectName("label_6")
         sizePolicy1.setHeightForWidth(self.label_6.sizePolicy().hasHeightForWidth())
         self.label_6.setSizePolicy(sizePolicy1)
         self.label_6.setMinimumSize(QSize(174, 39))
@@ -374,8 +404,10 @@ class Ui_RobustarLauncher(object):
         self.horizontalLayout_16.addWidget(self.label_6)
 
         self.trainPathDisplay = QLineEdit(self.layoutWidget3)
-        self.trainPathDisplay.setObjectName(u"trainPathDisplay")
-        sizePolicy1.setHeightForWidth(self.trainPathDisplay.sizePolicy().hasHeightForWidth())
+        self.trainPathDisplay.setObjectName("trainPathDisplay")
+        sizePolicy1.setHeightForWidth(
+            self.trainPathDisplay.sizePolicy().hasHeightForWidth()
+        )
         self.trainPathDisplay.setSizePolicy(sizePolicy1)
         self.trainPathDisplay.setMinimumSize(QSize(137, 24))
         self.trainPathDisplay.setMaximumSize(QSize(137, 24))
@@ -386,8 +418,10 @@ class Ui_RobustarLauncher(object):
         self.horizontalLayout_16.addWidget(self.trainPathDisplay)
 
         self.trainPathButton = QPushButton(self.layoutWidget3)
-        self.trainPathButton.setObjectName(u"trainPathButton")
-        sizePolicy1.setHeightForWidth(self.trainPathButton.sizePolicy().hasHeightForWidth())
+        self.trainPathButton.setObjectName("trainPathButton")
+        sizePolicy1.setHeightForWidth(
+            self.trainPathButton.sizePolicy().hasHeightForWidth()
+        )
         self.trainPathButton.setSizePolicy(sizePolicy1)
         self.trainPathButton.setMinimumSize(QSize(28, 20))
         self.trainPathButton.setMaximumSize(QSize(28, 20))
@@ -395,14 +429,56 @@ class Ui_RobustarLauncher(object):
 
         self.horizontalLayout_16.addWidget(self.trainPathButton)
 
-
         self.verticalLayout_7.addLayout(self.horizontalLayout_16)
 
+        self.horizontalLayout_validation_set = QHBoxLayout()
+        self.horizontalLayout_validation_set.setObjectName(
+            "horizontalLayout_validation_set"
+        )
+        self.horizontalLayout_validation_set.setContentsMargins(-1, -1, 0, -1)
+        self.label_validation_set = QLabel(self.layoutWidget3)
+        self.label_validation_set.setObjectName("label_validation_set")
+        sizePolicy1.setHeightForWidth(
+            self.label_validation_set.sizePolicy().hasHeightForWidth()
+        )
+        self.label_validation_set.setSizePolicy(sizePolicy1)
+        self.label_validation_set.setMinimumSize(QSize(174, 39))
+        self.label_validation_set.setMaximumSize(QSize(174, 39))
+        self.label_validation_set.setFont(font)
+
+        self.horizontalLayout_validation_set.addWidget(self.label_validation_set)
+
+        self.validationPathDisplay = QLineEdit(self.layoutWidget3)
+        self.validationPathDisplay.setObjectName("validationPathDisplay")
+        sizePolicy1.setHeightForWidth(
+            self.validationPathDisplay.sizePolicy().hasHeightForWidth()
+        )
+        self.validationPathDisplay.setSizePolicy(sizePolicy1)
+        self.validationPathDisplay.setMinimumSize(QSize(137, 24))
+        self.validationPathDisplay.setMaximumSize(QSize(137, 24))
+        self.validationPathDisplay.setFont(font)
+
+        self.horizontalLayout_validation_set.addWidget(self.validationPathDisplay)
+
+        self.validationPathButton = QPushButton(self.layoutWidget3)
+        self.validationPathButton.setObjectName("validationPathButton")
+        sizePolicy1.setHeightForWidth(
+            self.validationPathButton.sizePolicy().hasHeightForWidth()
+        )
+        self.validationPathButton.setSizePolicy(sizePolicy1)
+        self.validationPathButton.setMinimumSize(QSize(28, 20))
+        self.validationPathButton.setMaximumSize(QSize(28, 20))
+        self.validationPathButton.setFont(font)
+
+        self.horizontalLayout_validation_set.addWidget(self.validationPathButton)
+
+        self.verticalLayout_7.addLayout(self.horizontalLayout_validation_set)
+
         self.horizontalLayout_17 = QHBoxLayout()
-        self.horizontalLayout_17.setObjectName(u"horizontalLayout_17")
+        self.horizontalLayout_17.setObjectName("horizontalLayout_17")
         self.horizontalLayout_17.setContentsMargins(-1, -1, 0, -1)
         self.label_13 = QLabel(self.layoutWidget3)
-        self.label_13.setObjectName(u"label_13")
+        self.label_13.setObjectName("label_13")
         sizePolicy1.setHeightForWidth(self.label_13.sizePolicy().hasHeightForWidth())
         self.label_13.setSizePolicy(sizePolicy1)
         self.label_13.setMinimumSize(QSize(174, 39))
@@ -412,8 +488,10 @@ class Ui_RobustarLauncher(object):
         self.horizontalLayout_17.addWidget(self.label_13)
 
         self.testPathDisplay = QLineEdit(self.layoutWidget3)
-        self.testPathDisplay.setObjectName(u"testPathDisplay")
-        sizePolicy1.setHeightForWidth(self.testPathDisplay.sizePolicy().hasHeightForWidth())
+        self.testPathDisplay.setObjectName("testPathDisplay")
+        sizePolicy1.setHeightForWidth(
+            self.testPathDisplay.sizePolicy().hasHeightForWidth()
+        )
         self.testPathDisplay.setSizePolicy(sizePolicy1)
         self.testPathDisplay.setMinimumSize(QSize(137, 24))
         self.testPathDisplay.setMaximumSize(QSize(137, 24))
@@ -422,8 +500,10 @@ class Ui_RobustarLauncher(object):
         self.horizontalLayout_17.addWidget(self.testPathDisplay)
 
         self.testPathButton = QPushButton(self.layoutWidget3)
-        self.testPathButton.setObjectName(u"testPathButton")
-        sizePolicy1.setHeightForWidth(self.testPathButton.sizePolicy().hasHeightForWidth())
+        self.testPathButton.setObjectName("testPathButton")
+        sizePolicy1.setHeightForWidth(
+            self.testPathButton.sizePolicy().hasHeightForWidth()
+        )
         self.testPathButton.setSizePolicy(sizePolicy1)
         self.testPathButton.setMinimumSize(QSize(28, 20))
         self.testPathButton.setMaximumSize(QSize(28, 20))
@@ -431,13 +511,12 @@ class Ui_RobustarLauncher(object):
 
         self.horizontalLayout_17.addWidget(self.testPathButton)
 
-
         self.verticalLayout_7.addLayout(self.horizontalLayout_17)
 
         self.horizontalLayout_18 = QHBoxLayout()
-        self.horizontalLayout_18.setObjectName(u"horizontalLayout_18")
+        self.horizontalLayout_18.setObjectName("horizontalLayout_18")
         self.label_14 = QLabel(self.layoutWidget3)
-        self.label_14.setObjectName(u"label_14")
+        self.label_14.setObjectName("label_14")
         sizePolicy1.setHeightForWidth(self.label_14.sizePolicy().hasHeightForWidth())
         self.label_14.setSizePolicy(sizePolicy1)
         self.label_14.setMinimumSize(QSize(174, 39))
@@ -447,8 +526,10 @@ class Ui_RobustarLauncher(object):
         self.horizontalLayout_18.addWidget(self.label_14)
 
         self.checkPointPathDisplay = QLineEdit(self.layoutWidget3)
-        self.checkPointPathDisplay.setObjectName(u"checkPointPathDisplay")
-        sizePolicy1.setHeightForWidth(self.checkPointPathDisplay.sizePolicy().hasHeightForWidth())
+        self.checkPointPathDisplay.setObjectName("checkPointPathDisplay")
+        sizePolicy1.setHeightForWidth(
+            self.checkPointPathDisplay.sizePolicy().hasHeightForWidth()
+        )
         self.checkPointPathDisplay.setSizePolicy(sizePolicy1)
         self.checkPointPathDisplay.setMinimumSize(QSize(137, 24))
         self.checkPointPathDisplay.setMaximumSize(QSize(137, 24))
@@ -457,8 +538,10 @@ class Ui_RobustarLauncher(object):
         self.horizontalLayout_18.addWidget(self.checkPointPathDisplay)
 
         self.checkPointPathButton = QPushButton(self.layoutWidget3)
-        self.checkPointPathButton.setObjectName(u"checkPointPathButton")
-        sizePolicy1.setHeightForWidth(self.checkPointPathButton.sizePolicy().hasHeightForWidth())
+        self.checkPointPathButton.setObjectName("checkPointPathButton")
+        sizePolicy1.setHeightForWidth(
+            self.checkPointPathButton.sizePolicy().hasHeightForWidth()
+        )
         self.checkPointPathButton.setSizePolicy(sizePolicy1)
         self.checkPointPathButton.setMinimumSize(QSize(28, 20))
         self.checkPointPathButton.setMaximumSize(QSize(28, 20))
@@ -466,13 +549,12 @@ class Ui_RobustarLauncher(object):
 
         self.horizontalLayout_18.addWidget(self.checkPointPathButton)
 
-
         self.verticalLayout_7.addLayout(self.horizontalLayout_18)
 
         self.horizontalLayout_19 = QHBoxLayout()
-        self.horizontalLayout_19.setObjectName(u"horizontalLayout_19")
+        self.horizontalLayout_19.setObjectName("horizontalLayout_19")
         self.label_15 = QLabel(self.layoutWidget3)
-        self.label_15.setObjectName(u"label_15")
+        self.label_15.setObjectName("label_15")
         sizePolicy1.setHeightForWidth(self.label_15.sizePolicy().hasHeightForWidth())
         self.label_15.setSizePolicy(sizePolicy1)
         self.label_15.setMinimumSize(QSize(174, 39))
@@ -482,8 +564,10 @@ class Ui_RobustarLauncher(object):
         self.horizontalLayout_19.addWidget(self.label_15)
 
         self.influencePathDisplay = QLineEdit(self.layoutWidget3)
-        self.influencePathDisplay.setObjectName(u"influencePathDisplay")
-        sizePolicy1.setHeightForWidth(self.influencePathDisplay.sizePolicy().hasHeightForWidth())
+        self.influencePathDisplay.setObjectName("influencePathDisplay")
+        sizePolicy1.setHeightForWidth(
+            self.influencePathDisplay.sizePolicy().hasHeightForWidth()
+        )
         self.influencePathDisplay.setSizePolicy(sizePolicy1)
         self.influencePathDisplay.setMinimumSize(QSize(137, 24))
         self.influencePathDisplay.setMaximumSize(QSize(137, 24))
@@ -492,8 +576,10 @@ class Ui_RobustarLauncher(object):
         self.horizontalLayout_19.addWidget(self.influencePathDisplay)
 
         self.influencePathButton = QPushButton(self.layoutWidget3)
-        self.influencePathButton.setObjectName(u"influencePathButton")
-        sizePolicy1.setHeightForWidth(self.influencePathButton.sizePolicy().hasHeightForWidth())
+        self.influencePathButton.setObjectName("influencePathButton")
+        sizePolicy1.setHeightForWidth(
+            self.influencePathButton.sizePolicy().hasHeightForWidth()
+        )
         self.influencePathButton.setSizePolicy(sizePolicy1)
         self.influencePathButton.setMinimumSize(QSize(28, 20))
         self.influencePathButton.setMaximumSize(QSize(28, 20))
@@ -501,34 +587,33 @@ class Ui_RobustarLauncher(object):
 
         self.horizontalLayout_19.addWidget(self.influencePathButton)
 
-
         self.verticalLayout_7.addLayout(self.horizontalLayout_19)
 
-
         self.verticalLayout_3.addWidget(self.dataGroupBox)
-
 
         self.horizontalLayout_3.addLayout(self.verticalLayout_3)
 
         self.verticalLayout_4 = QVBoxLayout()
-        self.verticalLayout_4.setObjectName(u"verticalLayout_4")
+        self.verticalLayout_4.setObjectName("verticalLayout_4")
         self.dockerGroupBox_2 = QGroupBox(self.horizontalLayoutWidget_7)
-        self.dockerGroupBox_2.setObjectName(u"dockerGroupBox_2")
-        sizePolicy1.setHeightForWidth(self.dockerGroupBox_2.sizePolicy().hasHeightForWidth())
+        self.dockerGroupBox_2.setObjectName("dockerGroupBox_2")
+        sizePolicy1.setHeightForWidth(
+            self.dockerGroupBox_2.sizePolicy().hasHeightForWidth()
+        )
         self.dockerGroupBox_2.setSizePolicy(sizePolicy1)
         self.dockerGroupBox_2.setMinimumSize(QSize(372, 525))
         self.dockerGroupBox_2.setMaximumSize(QSize(372, 525))
         self.dockerGroupBox_2.setFont(font)
         self.layoutWidget_2 = QWidget(self.dockerGroupBox_2)
-        self.layoutWidget_2.setObjectName(u"layoutWidget_2")
+        self.layoutWidget_2.setObjectName("layoutWidget_2")
         self.layoutWidget_2.setGeometry(QRect(10, 20, 362, 493))
         self.verticalLayout_9 = QVBoxLayout(self.layoutWidget_2)
-        self.verticalLayout_9.setObjectName(u"verticalLayout_9")
+        self.verticalLayout_9.setObjectName("verticalLayout_9")
         self.verticalLayout_9.setContentsMargins(0, 0, 0, 0)
         self.horizontalLayout_7 = QHBoxLayout()
-        self.horizontalLayout_7.setObjectName(u"horizontalLayout_7")
+        self.horizontalLayout_7.setObjectName("horizontalLayout_7")
         self.label_4 = QLabel(self.layoutWidget_2)
-        self.label_4.setObjectName(u"label_4")
+        self.label_4.setObjectName("label_4")
         sizePolicy1.setHeightForWidth(self.label_4.sizePolicy().hasHeightForWidth())
         self.label_4.setSizePolicy(sizePolicy1)
         self.label_4.setMinimumSize(QSize(174, 39))
@@ -546,8 +631,10 @@ class Ui_RobustarLauncher(object):
         self.archComboBox.addItem("")
         self.archComboBox.addItem("")
         self.archComboBox.addItem("")
-        self.archComboBox.setObjectName(u"archComboBox")
-        sizePolicy1.setHeightForWidth(self.archComboBox.sizePolicy().hasHeightForWidth())
+        self.archComboBox.setObjectName("archComboBox")
+        sizePolicy1.setHeightForWidth(
+            self.archComboBox.sizePolicy().hasHeightForWidth()
+        )
         self.archComboBox.setSizePolicy(sizePolicy1)
         self.archComboBox.setMinimumSize(QSize(174, 24))
         self.archComboBox.setMaximumSize(QSize(174, 24))
@@ -555,13 +642,12 @@ class Ui_RobustarLauncher(object):
 
         self.horizontalLayout_7.addWidget(self.archComboBox)
 
-
         self.verticalLayout_9.addLayout(self.horizontalLayout_7)
 
         self.horizontalLayout_4 = QHBoxLayout()
-        self.horizontalLayout_4.setObjectName(u"horizontalLayout_4")
+        self.horizontalLayout_4.setObjectName("horizontalLayout_4")
         self.label_9 = QLabel(self.layoutWidget_2)
-        self.label_9.setObjectName(u"label_9")
+        self.label_9.setObjectName("label_9")
         sizePolicy1.setHeightForWidth(self.label_9.sizePolicy().hasHeightForWidth())
         self.label_9.setSizePolicy(sizePolicy1)
         self.label_9.setMinimumSize(QSize(174, 39))
@@ -571,21 +657,22 @@ class Ui_RobustarLauncher(object):
         self.horizontalLayout_4.addWidget(self.label_9)
 
         self.pretrainedCheckBox = QCheckBox(self.layoutWidget_2)
-        self.pretrainedCheckBox.setObjectName(u"pretrainedCheckBox")
-        sizePolicy1.setHeightForWidth(self.pretrainedCheckBox.sizePolicy().hasHeightForWidth())
+        self.pretrainedCheckBox.setObjectName("pretrainedCheckBox")
+        sizePolicy1.setHeightForWidth(
+            self.pretrainedCheckBox.sizePolicy().hasHeightForWidth()
+        )
         self.pretrainedCheckBox.setSizePolicy(sizePolicy1)
         self.pretrainedCheckBox.setMinimumSize(QSize(174, 24))
         self.pretrainedCheckBox.setMaximumSize(QSize(174, 24))
 
         self.horizontalLayout_4.addWidget(self.pretrainedCheckBox)
 
-
         self.verticalLayout_9.addLayout(self.horizontalLayout_4)
 
         self.horizontalLayout_14 = QHBoxLayout()
-        self.horizontalLayout_14.setObjectName(u"horizontalLayout_14")
+        self.horizontalLayout_14.setObjectName("horizontalLayout_14")
         self.label_16 = QLabel(self.layoutWidget_2)
-        self.label_16.setObjectName(u"label_16")
+        self.label_16.setObjectName("label_16")
         sizePolicy1.setHeightForWidth(self.label_16.sizePolicy().hasHeightForWidth())
         self.label_16.setSizePolicy(sizePolicy1)
         self.label_16.setMinimumSize(QSize(174, 39))
@@ -596,8 +683,10 @@ class Ui_RobustarLauncher(object):
 
         self.weightFileComboBox = QComboBox(self.layoutWidget_2)
         self.weightFileComboBox.addItem("")
-        self.weightFileComboBox.setObjectName(u"weightFileComboBox")
-        sizePolicy1.setHeightForWidth(self.weightFileComboBox.sizePolicy().hasHeightForWidth())
+        self.weightFileComboBox.setObjectName("weightFileComboBox")
+        sizePolicy1.setHeightForWidth(
+            self.weightFileComboBox.sizePolicy().hasHeightForWidth()
+        )
         self.weightFileComboBox.setSizePolicy(sizePolicy1)
         self.weightFileComboBox.setMinimumSize(QSize(174, 24))
         self.weightFileComboBox.setMaximumSize(QSize(174, 24))
@@ -605,13 +694,12 @@ class Ui_RobustarLauncher(object):
 
         self.horizontalLayout_14.addWidget(self.weightFileComboBox)
 
-
         self.verticalLayout_9.addLayout(self.horizontalLayout_14)
 
         self.horizontalLayout_21 = QHBoxLayout()
-        self.horizontalLayout_21.setObjectName(u"horizontalLayout_21")
+        self.horizontalLayout_21.setObjectName("horizontalLayout_21")
         self.label_19 = QLabel(self.layoutWidget_2)
-        self.label_19.setObjectName(u"label_19")
+        self.label_19.setObjectName("label_19")
         sizePolicy1.setHeightForWidth(self.label_19.sizePolicy().hasHeightForWidth())
         self.label_19.setSizePolicy(sizePolicy1)
         self.label_19.setMinimumSize(QSize(174, 39))
@@ -621,24 +709,23 @@ class Ui_RobustarLauncher(object):
         self.horizontalLayout_21.addWidget(self.label_19)
 
         self.deviceInput = QLineEdit(self.layoutWidget_2)
-        self.deviceInput.setObjectName(u"deviceInput")
+        self.deviceInput.setObjectName("deviceInput")
         sizePolicy1.setHeightForWidth(self.deviceInput.sizePolicy().hasHeightForWidth())
         self.deviceInput.setSizePolicy(sizePolicy1)
         self.deviceInput.setMinimumSize(QSize(174, 24))
         self.deviceInput.setMaximumSize(QSize(174, 24))
         self.deviceInput.setFont(font)
-        self.deviceInput.setAlignment(Qt.AlignLeading|Qt.AlignLeft|Qt.AlignVCenter)
+        self.deviceInput.setAlignment(Qt.AlignLeading | Qt.AlignLeft | Qt.AlignVCenter)
         self.deviceInput.setClearButtonEnabled(True)
 
         self.horizontalLayout_21.addWidget(self.deviceInput)
 
-
         self.verticalLayout_9.addLayout(self.horizontalLayout_21)
 
         self.horizontalLayout_23 = QHBoxLayout()
-        self.horizontalLayout_23.setObjectName(u"horizontalLayout_23")
+        self.horizontalLayout_23.setObjectName("horizontalLayout_23")
         self.label_20 = QLabel(self.layoutWidget_2)
-        self.label_20.setObjectName(u"label_20")
+        self.label_20.setObjectName("label_20")
         sizePolicy1.setHeightForWidth(self.label_20.sizePolicy().hasHeightForWidth())
         self.label_20.setSizePolicy(sizePolicy1)
         self.label_20.setMinimumSize(QSize(174, 39))
@@ -648,21 +735,22 @@ class Ui_RobustarLauncher(object):
         self.horizontalLayout_23.addWidget(self.label_20)
 
         self.shuffleCheckBox = QCheckBox(self.layoutWidget_2)
-        self.shuffleCheckBox.setObjectName(u"shuffleCheckBox")
-        sizePolicy1.setHeightForWidth(self.shuffleCheckBox.sizePolicy().hasHeightForWidth())
+        self.shuffleCheckBox.setObjectName("shuffleCheckBox")
+        sizePolicy1.setHeightForWidth(
+            self.shuffleCheckBox.sizePolicy().hasHeightForWidth()
+        )
         self.shuffleCheckBox.setSizePolicy(sizePolicy1)
         self.shuffleCheckBox.setMinimumSize(QSize(174, 24))
         self.shuffleCheckBox.setMaximumSize(QSize(174, 24))
 
         self.horizontalLayout_23.addWidget(self.shuffleCheckBox)
 
-
         self.verticalLayout_9.addLayout(self.horizontalLayout_23)
 
         self.horizontalLayout_24 = QHBoxLayout()
-        self.horizontalLayout_24.setObjectName(u"horizontalLayout_24")
+        self.horizontalLayout_24.setObjectName("horizontalLayout_24")
         self.label_21 = QLabel(self.layoutWidget_2)
-        self.label_21.setObjectName(u"label_21")
+        self.label_21.setObjectName("label_21")
         sizePolicy1.setHeightForWidth(self.label_21.sizePolicy().hasHeightForWidth())
         self.label_21.setSizePolicy(sizePolicy1)
         self.label_21.setMinimumSize(QSize(174, 39))
@@ -672,24 +760,27 @@ class Ui_RobustarLauncher(object):
         self.horizontalLayout_24.addWidget(self.label_21)
 
         self.batchSizeInput = QLineEdit(self.layoutWidget_2)
-        self.batchSizeInput.setObjectName(u"batchSizeInput")
-        sizePolicy1.setHeightForWidth(self.batchSizeInput.sizePolicy().hasHeightForWidth())
+        self.batchSizeInput.setObjectName("batchSizeInput")
+        sizePolicy1.setHeightForWidth(
+            self.batchSizeInput.sizePolicy().hasHeightForWidth()
+        )
         self.batchSizeInput.setSizePolicy(sizePolicy1)
         self.batchSizeInput.setMinimumSize(QSize(174, 24))
         self.batchSizeInput.setMaximumSize(QSize(174, 24))
         self.batchSizeInput.setFont(font)
-        self.batchSizeInput.setAlignment(Qt.AlignLeading|Qt.AlignLeft|Qt.AlignVCenter)
+        self.batchSizeInput.setAlignment(
+            Qt.AlignLeading | Qt.AlignLeft | Qt.AlignVCenter
+        )
         self.batchSizeInput.setClearButtonEnabled(True)
 
         self.horizontalLayout_24.addWidget(self.batchSizeInput)
 
-
         self.verticalLayout_9.addLayout(self.horizontalLayout_24)
 
         self.horizontalLayout_25 = QHBoxLayout()
-        self.horizontalLayout_25.setObjectName(u"horizontalLayout_25")
+        self.horizontalLayout_25.setObjectName("horizontalLayout_25")
         self.label_22 = QLabel(self.layoutWidget_2)
-        self.label_22.setObjectName(u"label_22")
+        self.label_22.setObjectName("label_22")
         sizePolicy1.setHeightForWidth(self.label_22.sizePolicy().hasHeightForWidth())
         self.label_22.setSizePolicy(sizePolicy1)
         self.label_22.setMinimumSize(QSize(174, 39))
@@ -699,24 +790,27 @@ class Ui_RobustarLauncher(object):
         self.horizontalLayout_25.addWidget(self.label_22)
 
         self.workerNumberInput = QLineEdit(self.layoutWidget_2)
-        self.workerNumberInput.setObjectName(u"workerNumberInput")
-        sizePolicy1.setHeightForWidth(self.workerNumberInput.sizePolicy().hasHeightForWidth())
+        self.workerNumberInput.setObjectName("workerNumberInput")
+        sizePolicy1.setHeightForWidth(
+            self.workerNumberInput.sizePolicy().hasHeightForWidth()
+        )
         self.workerNumberInput.setSizePolicy(sizePolicy1)
         self.workerNumberInput.setMinimumSize(QSize(174, 24))
         self.workerNumberInput.setMaximumSize(QSize(174, 24))
         self.workerNumberInput.setFont(font)
-        self.workerNumberInput.setAlignment(Qt.AlignLeading|Qt.AlignLeft|Qt.AlignVCenter)
+        self.workerNumberInput.setAlignment(
+            Qt.AlignLeading | Qt.AlignLeft | Qt.AlignVCenter
+        )
         self.workerNumberInput.setClearButtonEnabled(True)
 
         self.horizontalLayout_25.addWidget(self.workerNumberInput)
 
-
         self.verticalLayout_9.addLayout(self.horizontalLayout_25)
 
         self.horizontalLayout_28 = QHBoxLayout()
-        self.horizontalLayout_28.setObjectName(u"horizontalLayout_28")
+        self.horizontalLayout_28.setObjectName("horizontalLayout_28")
         self.label_25 = QLabel(self.layoutWidget_2)
-        self.label_25.setObjectName(u"label_25")
+        self.label_25.setObjectName("label_25")
         sizePolicy1.setHeightForWidth(self.label_25.sizePolicy().hasHeightForWidth())
         self.label_25.setSizePolicy(sizePolicy1)
         self.label_25.setMinimumSize(QSize(174, 39))
@@ -726,24 +820,27 @@ class Ui_RobustarLauncher(object):
         self.horizontalLayout_28.addWidget(self.label_25)
 
         self.classNumberInput = QLineEdit(self.layoutWidget_2)
-        self.classNumberInput.setObjectName(u"classNumberInput")
-        sizePolicy1.setHeightForWidth(self.classNumberInput.sizePolicy().hasHeightForWidth())
+        self.classNumberInput.setObjectName("classNumberInput")
+        sizePolicy1.setHeightForWidth(
+            self.classNumberInput.sizePolicy().hasHeightForWidth()
+        )
         self.classNumberInput.setSizePolicy(sizePolicy1)
         self.classNumberInput.setMinimumSize(QSize(174, 24))
         self.classNumberInput.setMaximumSize(QSize(174, 24))
         self.classNumberInput.setFont(font)
-        self.classNumberInput.setAlignment(Qt.AlignLeading|Qt.AlignLeft|Qt.AlignVCenter)
+        self.classNumberInput.setAlignment(
+            Qt.AlignLeading | Qt.AlignLeft | Qt.AlignVCenter
+        )
         self.classNumberInput.setClearButtonEnabled(True)
 
         self.horizontalLayout_28.addWidget(self.classNumberInput)
 
-
         self.verticalLayout_9.addLayout(self.horizontalLayout_28)
 
         self.horizontalLayout_26 = QHBoxLayout()
-        self.horizontalLayout_26.setObjectName(u"horizontalLayout_26")
+        self.horizontalLayout_26.setObjectName("horizontalLayout_26")
         self.label_23 = QLabel(self.layoutWidget_2)
-        self.label_23.setObjectName(u"label_23")
+        self.label_23.setObjectName("label_23")
         sizePolicy1.setHeightForWidth(self.label_23.sizePolicy().hasHeightForWidth())
         self.label_23.setSizePolicy(sizePolicy1)
         self.label_23.setMinimumSize(QSize(174, 39))
@@ -753,24 +850,25 @@ class Ui_RobustarLauncher(object):
         self.horizontalLayout_26.addWidget(self.label_23)
 
         self.imgSizeInput = QLineEdit(self.layoutWidget_2)
-        self.imgSizeInput.setObjectName(u"imgSizeInput")
-        sizePolicy1.setHeightForWidth(self.imgSizeInput.sizePolicy().hasHeightForWidth())
+        self.imgSizeInput.setObjectName("imgSizeInput")
+        sizePolicy1.setHeightForWidth(
+            self.imgSizeInput.sizePolicy().hasHeightForWidth()
+        )
         self.imgSizeInput.setSizePolicy(sizePolicy1)
         self.imgSizeInput.setMinimumSize(QSize(174, 24))
         self.imgSizeInput.setMaximumSize(QSize(174, 24))
         self.imgSizeInput.setFont(font)
-        self.imgSizeInput.setAlignment(Qt.AlignLeading|Qt.AlignLeft|Qt.AlignVCenter)
+        self.imgSizeInput.setAlignment(Qt.AlignLeading | Qt.AlignLeft | Qt.AlignVCenter)
         self.imgSizeInput.setClearButtonEnabled(True)
 
         self.horizontalLayout_26.addWidget(self.imgSizeInput)
 
-
         self.verticalLayout_9.addLayout(self.horizontalLayout_26)
 
         self.horizontalLayout_27 = QHBoxLayout()
-        self.horizontalLayout_27.setObjectName(u"horizontalLayout_27")
+        self.horizontalLayout_27.setObjectName("horizontalLayout_27")
         self.label_24 = QLabel(self.layoutWidget_2)
-        self.label_24.setObjectName(u"label_24")
+        self.label_24.setObjectName("label_24")
         sizePolicy1.setHeightForWidth(self.label_24.sizePolicy().hasHeightForWidth())
         self.label_24.setSizePolicy(sizePolicy1)
         self.label_24.setMinimumSize(QSize(174, 39))
@@ -782,8 +880,10 @@ class Ui_RobustarLauncher(object):
         self.paddingComboBox = QComboBox(self.layoutWidget_2)
         self.paddingComboBox.addItem("")
         self.paddingComboBox.addItem("")
-        self.paddingComboBox.setObjectName(u"paddingComboBox")
-        sizePolicy1.setHeightForWidth(self.paddingComboBox.sizePolicy().hasHeightForWidth())
+        self.paddingComboBox.setObjectName("paddingComboBox")
+        sizePolicy1.setHeightForWidth(
+            self.paddingComboBox.sizePolicy().hasHeightForWidth()
+        )
         self.paddingComboBox.setSizePolicy(sizePolicy1)
         self.paddingComboBox.setMinimumSize(QSize(174, 24))
         self.paddingComboBox.setMaximumSize(QSize(174, 24))
@@ -791,36 +891,34 @@ class Ui_RobustarLauncher(object):
 
         self.horizontalLayout_27.addWidget(self.paddingComboBox)
 
-
         self.verticalLayout_9.addLayout(self.horizontalLayout_27)
-
 
         self.verticalLayout_4.addWidget(self.dockerGroupBox_2)
 
-
         self.horizontalLayout_3.addLayout(self.verticalLayout_4)
-
 
         self.horizontalLayout_6.addLayout(self.horizontalLayout_3)
 
         self.tabWidget.addTab(self.createTab, "")
         self.manageTab = QWidget()
-        self.manageTab.setObjectName(u"manageTab")
+        self.manageTab.setObjectName("manageTab")
         self.layoutWidget4 = QWidget(self.manageTab)
-        self.layoutWidget4.setObjectName(u"layoutWidget4")
+        self.layoutWidget4.setObjectName("layoutWidget4")
         self.layoutWidget4.setGeometry(QRect(20, 10, 771, 401))
         self.horizontalLayout_20 = QHBoxLayout(self.layoutWidget4)
-        self.horizontalLayout_20.setObjectName(u"horizontalLayout_20")
+        self.horizontalLayout_20.setObjectName("horizontalLayout_20")
         self.horizontalLayout_20.setContentsMargins(0, 0, 0, 0)
         self.verticalLayout_8 = QVBoxLayout()
-        self.verticalLayout_8.setObjectName(u"verticalLayout_8")
+        self.verticalLayout_8.setObjectName("verticalLayout_8")
         self.groupBox_2 = QGroupBox(self.layoutWidget4)
-        self.groupBox_2.setObjectName(u"groupBox_2")
+        self.groupBox_2.setObjectName("groupBox_2")
         self.groupBox_2.setFont(font)
         self.exitedListWidget = QListWidget(self.groupBox_2)
-        self.exitedListWidget.setObjectName(u"exitedListWidget")
+        self.exitedListWidget.setObjectName("exitedListWidget")
         self.exitedListWidget.setGeometry(QRect(10, 30, 361, 161))
-        sizePolicy1.setHeightForWidth(self.exitedListWidget.sizePolicy().hasHeightForWidth())
+        sizePolicy1.setHeightForWidth(
+            self.exitedListWidget.sizePolicy().hasHeightForWidth()
+        )
         self.exitedListWidget.setSizePolicy(sizePolicy1)
         self.exitedListWidget.setMinimumSize(QSize(361, 161))
         self.exitedListWidget.setMaximumSize(QSize(361, 161))
@@ -828,12 +926,14 @@ class Ui_RobustarLauncher(object):
         self.verticalLayout_8.addWidget(self.groupBox_2)
 
         self.groupBox_3 = QGroupBox(self.layoutWidget4)
-        self.groupBox_3.setObjectName(u"groupBox_3")
+        self.groupBox_3.setObjectName("groupBox_3")
         self.groupBox_3.setFont(font)
         self.createdListWidget = QListWidget(self.groupBox_3)
-        self.createdListWidget.setObjectName(u"createdListWidget")
+        self.createdListWidget.setObjectName("createdListWidget")
         self.createdListWidget.setGeometry(QRect(10, 20, 361, 171))
-        sizePolicy1.setHeightForWidth(self.createdListWidget.sizePolicy().hasHeightForWidth())
+        sizePolicy1.setHeightForWidth(
+            self.createdListWidget.sizePolicy().hasHeightForWidth()
+        )
         self.createdListWidget.setSizePolicy(sizePolicy1)
         self.createdListWidget.setMinimumSize(QSize(361, 171))
         self.createdListWidget.setMaximumSize(QSize(361, 171))
@@ -846,12 +946,14 @@ class Ui_RobustarLauncher(object):
         self.horizontalLayout_20.addLayout(self.verticalLayout_8)
 
         self.groupBox = QGroupBox(self.layoutWidget4)
-        self.groupBox.setObjectName(u"groupBox")
+        self.groupBox.setObjectName("groupBox")
         self.groupBox.setFont(font)
         self.runningListWidget = QListWidget(self.groupBox)
-        self.runningListWidget.setObjectName(u"runningListWidget")
+        self.runningListWidget.setObjectName("runningListWidget")
         self.runningListWidget.setGeometry(QRect(10, 30, 361, 361))
-        sizePolicy1.setHeightForWidth(self.runningListWidget.sizePolicy().hasHeightForWidth())
+        sizePolicy1.setHeightForWidth(
+            self.runningListWidget.sizePolicy().hasHeightForWidth()
+        )
         self.runningListWidget.setSizePolicy(sizePolicy1)
         self.runningListWidget.setMinimumSize(QSize(361, 361))
         self.runningListWidget.setMaximumSize(QSize(361, 361))
@@ -859,9 +961,11 @@ class Ui_RobustarLauncher(object):
         self.horizontalLayout_20.addWidget(self.groupBox)
 
         self.refreshListWidgetsButton = QPushButton(self.manageTab)
-        self.refreshListWidgetsButton.setObjectName(u"refreshListWidgetsButton")
+        self.refreshListWidgetsButton.setObjectName("refreshListWidgetsButton")
         self.refreshListWidgetsButton.setGeometry(QRect(717, 416, 75, 25))
-        sizePolicy1.setHeightForWidth(self.refreshListWidgetsButton.sizePolicy().hasHeightForWidth())
+        sizePolicy1.setHeightForWidth(
+            self.refreshListWidgetsButton.sizePolicy().hasHeightForWidth()
+        )
         self.refreshListWidgetsButton.setSizePolicy(sizePolicy1)
         self.refreshListWidgetsButton.setMinimumSize(QSize(75, 25))
         self.refreshListWidgetsButton.setMaximumSize(QSize(75, 25))
@@ -870,38 +974,42 @@ class Ui_RobustarLauncher(object):
         self.verticalLayout_2.addWidget(self.tabWidget)
 
         self.tabWidget_2 = QTabWidget(self.layoutWidget)
-        self.tabWidget_2.setObjectName(u"tabWidget_2")
+        self.tabWidget_2.setObjectName("tabWidget_2")
         sizePolicy1.setHeightForWidth(self.tabWidget_2.sizePolicy().hasHeightForWidth())
         self.tabWidget_2.setSizePolicy(sizePolicy1)
         self.tabWidget_2.setMinimumSize(QSize(801, 319))
         self.tabWidget_2.setMaximumSize(QSize(801, 319))
         self.tabWidget_2.setFont(font)
-        self.tabWidget_2.setStyleSheet(u"")
+        self.tabWidget_2.setStyleSheet("")
         self.tab = QWidget()
-        self.tab.setObjectName(u"tab")
+        self.tab.setObjectName("tab")
         self.promptBrowser = QTextBrowser(self.tab)
-        self.promptBrowser.setObjectName(u"promptBrowser")
+        self.promptBrowser.setObjectName("promptBrowser")
         self.promptBrowser.setGeometry(QRect(0, 0, 801, 311))
-        sizePolicy1.setHeightForWidth(self.promptBrowser.sizePolicy().hasHeightForWidth())
+        sizePolicy1.setHeightForWidth(
+            self.promptBrowser.sizePolicy().hasHeightForWidth()
+        )
         self.promptBrowser.setSizePolicy(sizePolicy1)
         self.promptBrowser.setMinimumSize(QSize(801, 311))
         self.promptBrowser.setMaximumSize(QSize(801, 311))
-        self.promptBrowser.setStyleSheet(u"")
+        self.promptBrowser.setStyleSheet("")
         self.tabWidget_2.addTab(self.tab, "")
         self.tab_2 = QWidget()
-        self.tab_2.setObjectName(u"tab_2")
+        self.tab_2.setObjectName("tab_2")
         self.detailBrowser = QTextBrowser(self.tab_2)
-        self.detailBrowser.setObjectName(u"detailBrowser")
+        self.detailBrowser.setObjectName("detailBrowser")
         self.detailBrowser.setGeometry(QRect(0, 0, 801, 311))
-        sizePolicy1.setHeightForWidth(self.detailBrowser.sizePolicy().hasHeightForWidth())
+        sizePolicy1.setHeightForWidth(
+            self.detailBrowser.sizePolicy().hasHeightForWidth()
+        )
         self.detailBrowser.setSizePolicy(sizePolicy1)
         self.detailBrowser.setMinimumSize(QSize(801, 311))
         self.detailBrowser.setMaximumSize(QSize(801, 311))
         self.tabWidget_2.addTab(self.tab_2, "")
         self.tab_3 = QWidget()
-        self.tab_3.setObjectName(u"tab_3")
+        self.tab_3.setObjectName("tab_3")
         self.logBrowser = QTextBrowser(self.tab_3)
-        self.logBrowser.setObjectName(u"logBrowser")
+        self.logBrowser.setObjectName("logBrowser")
         self.logBrowser.setGeometry(QRect(0, 0, 801, 311))
         sizePolicy1.setHeightForWidth(self.logBrowser.sizePolicy().hasHeightForWidth())
         self.logBrowser.setSizePolicy(sizePolicy1)
@@ -929,134 +1037,347 @@ class Ui_RobustarLauncher(object):
         self.tabWidget.setCurrentIndex(0)
         self.tabWidget_2.setCurrentIndex(0)
 
-
         QMetaObject.connectSlotsByName(RobustarLauncher)
+
     # setupUi
 
     def retranslateUi(self, RobustarLauncher):
-        RobustarLauncher.setWindowTitle(QCoreApplication.translate("RobustarLauncher", u"Robustar Launcher", None))
+        RobustarLauncher.setWindowTitle(
+            QCoreApplication.translate("RobustarLauncher", "Robustar Launcher", None)
+        )
         self.header.setText("")
-        self.loadProfileButton.setText(QCoreApplication.translate("RobustarLauncher", u"Load Profile", None))
-        self.saveProfileButton.setText(QCoreApplication.translate("RobustarLauncher", u"Save Profile", None))
-        self.startServerButton.setText(QCoreApplication.translate("RobustarLauncher", u"Start Server", None))
-        self.stopServerButton.setText(QCoreApplication.translate("RobustarLauncher", u"Stop Server", None))
-        self.deleteServerButton.setText(QCoreApplication.translate("RobustarLauncher", u"Delete Server", None))
-        self.dockerGroupBox.setTitle(QCoreApplication.translate("RobustarLauncher", u"Docker", None))
-#if QT_CONFIG(tooltip)
-        self.label_8.setToolTip(QCoreApplication.translate("RobustarLauncher", u"The name of the docker container", None))
-#endif // QT_CONFIG(tooltip)
-        self.label_8.setText(QCoreApplication.translate("RobustarLauncher", u"Container Name", None))
-        self.nameInput.setText(QCoreApplication.translate("RobustarLauncher", u"robustar", None))
-#if QT_CONFIG(tooltip)
-        self.label_3.setToolTip(QCoreApplication.translate("RobustarLauncher", u"The version of the docker image of the container", None))
-#endif // QT_CONFIG(tooltip)
-        self.label_3.setText(QCoreApplication.translate("RobustarLauncher", u"Image Version", None))
+        self.loadProfileButton.setText(
+            QCoreApplication.translate("RobustarLauncher", "Load Profile", None)
+        )
+        self.saveProfileButton.setText(
+            QCoreApplication.translate("RobustarLauncher", "Save Profile", None)
+        )
+        self.startServerButton.setText(
+            QCoreApplication.translate("RobustarLauncher", "Start Server", None)
+        )
+        self.stopServerButton.setText(
+            QCoreApplication.translate("RobustarLauncher", "Stop Server", None)
+        )
+        self.deleteServerButton.setText(
+            QCoreApplication.translate("RobustarLauncher", "Delete Server", None)
+        )
+        self.dockerGroupBox.setTitle(
+            QCoreApplication.translate("RobustarLauncher", "Docker", None)
+        )
+        # if QT_CONFIG(tooltip)
+        self.label_8.setToolTip(
+            QCoreApplication.translate(
+                "RobustarLauncher", "The name of the docker container", None
+            )
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.label_8.setText(
+            QCoreApplication.translate("RobustarLauncher", "Container Name", None)
+        )
+        self.nameInput.setText(
+            QCoreApplication.translate("RobustarLauncher", "robustar", None)
+        )
+        # if QT_CONFIG(tooltip)
+        self.label_3.setToolTip(
+            QCoreApplication.translate(
+                "RobustarLauncher",
+                "The version of the docker image of the container",
+                None,
+            )
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.label_3.setText(
+            QCoreApplication.translate("RobustarLauncher", "Image Version", None)
+        )
         self.versionComboBox.setProperty("placeholderText", "")
-#if QT_CONFIG(tooltip)
-        self.label_7.setToolTip(QCoreApplication.translate("RobustarLauncher", u"The port the docker container forwards to", None))
-#endif // QT_CONFIG(tooltip)
-        self.label_7.setText(QCoreApplication.translate("RobustarLauncher", u"Port", None))
-        self.portInput.setText(QCoreApplication.translate("RobustarLauncher", u"8000", None))
-        self.dataGroupBox.setTitle(QCoreApplication.translate("RobustarLauncher", u"Data", None))
-#if QT_CONFIG(tooltip)
-        self.label_6.setToolTip(QCoreApplication.translate("RobustarLauncher", u"The root path of the train set", None))
-#endif // QT_CONFIG(tooltip)
-        self.label_6.setText(QCoreApplication.translate("RobustarLauncher", u"Train Set", None))
+        # if QT_CONFIG(tooltip)
+        self.label_7.setToolTip(
+            QCoreApplication.translate(
+                "RobustarLauncher", "The port the docker container forwards to", None
+            )
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.label_7.setText(
+            QCoreApplication.translate("RobustarLauncher", "Port", None)
+        )
+        self.portInput.setText(
+            QCoreApplication.translate("RobustarLauncher", "8000", None)
+        )
+        self.dataGroupBox.setTitle(
+            QCoreApplication.translate("RobustarLauncher", "Data", None)
+        )
+        # if QT_CONFIG(tooltip)
+        self.label_6.setToolTip(
+            QCoreApplication.translate(
+                "RobustarLauncher", "The root path of the train set", None
+            )
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.label_6.setText(
+            QCoreApplication.translate("RobustarLauncher", "Train Set", None)
+        )
         self.trainPathDisplay.setText("")
-        self.trainPathButton.setText(QCoreApplication.translate("RobustarLauncher", u"...", None))
-#if QT_CONFIG(tooltip)
-        self.label_13.setToolTip(QCoreApplication.translate("RobustarLauncher", u"The root path of the test set", None))
-#endif // QT_CONFIG(tooltip)
-        self.label_13.setText(QCoreApplication.translate("RobustarLauncher", u"Test Set", None))
+        self.trainPathButton.setText(
+            QCoreApplication.translate("RobustarLauncher", "...", None)
+        )
+        # if QT_CONFIG(tooltip)
+        self.label_validation_set.setToolTip(
+            QCoreApplication.translate(
+                "RobustarLauncher", "The root path of the validation set", None
+            )
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.label_validation_set.setText(
+            QCoreApplication.translate("RobustarLauncher", "Validation Set", None)
+        )
+        self.validationPathDisplay.setText("")
+        self.validationPathButton.setText(
+            QCoreApplication.translate("RobustarLauncher", "...", None)
+        )
+        # if QT_CONFIG(tooltip)
+        self.label_13.setToolTip(
+            QCoreApplication.translate(
+                "RobustarLauncher",
+                "The root path of the test set. If you don't want to use a test set, please use the same path as the validation set.",
+                None,
+            )
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.label_13.setText(
+            QCoreApplication.translate("RobustarLauncher", "Test Set", None)
+        )
         self.testPathDisplay.setText("")
-        self.testPathButton.setText(QCoreApplication.translate("RobustarLauncher", u"...", None))
-#if QT_CONFIG(tooltip)
-        self.label_14.setToolTip(QCoreApplication.translate("RobustarLauncher", u"The root path for all checkpoint files saved by Robustar", None))
-#endif // QT_CONFIG(tooltip)
-        self.label_14.setText(QCoreApplication.translate("RobustarLauncher", u"Checkpoint", None))
+        self.testPathButton.setText(
+            QCoreApplication.translate("RobustarLauncher", "...", None)
+        )
+        # if QT_CONFIG(tooltip)
+        self.label_14.setToolTip(
+            QCoreApplication.translate(
+                "RobustarLauncher",
+                "The root path for all checkpoint files saved by Robustar",
+                None,
+            )
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.label_14.setText(
+            QCoreApplication.translate("RobustarLauncher", "Checkpoint", None)
+        )
         self.checkPointPathDisplay.setText("")
-        self.checkPointPathButton.setText(QCoreApplication.translate("RobustarLauncher", u"...", None))
-#if QT_CONFIG(tooltip)
-        self.label_15.setToolTip(QCoreApplication.translate("RobustarLauncher", u"The root path for all influence result calculated by Robustar", None))
-#endif // QT_CONFIG(tooltip)
-        self.label_15.setText(QCoreApplication.translate("RobustarLauncher", u"Influence Result", None))
+        self.checkPointPathButton.setText(
+            QCoreApplication.translate("RobustarLauncher", "...", None)
+        )
+        # if QT_CONFIG(tooltip)
+        self.label_15.setToolTip(
+            QCoreApplication.translate(
+                "RobustarLauncher",
+                "The root path for all influence result calculated by Robustar",
+                None,
+            )
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.label_15.setText(
+            QCoreApplication.translate("RobustarLauncher", "Influence Result", None)
+        )
         self.influencePathDisplay.setText("")
-        self.influencePathButton.setText(QCoreApplication.translate("RobustarLauncher", u"...", None))
-        self.dockerGroupBox_2.setTitle(QCoreApplication.translate("RobustarLauncher", u"Model", None))
-#if QT_CONFIG(tooltip)
-        self.label_4.setToolTip(QCoreApplication.translate("RobustarLauncher", u"The architecture of the model", None))
-#endif // QT_CONFIG(tooltip)
-        self.label_4.setText(QCoreApplication.translate("RobustarLauncher", u"Architecture", None))
-        self.archComboBox.setItemText(0, QCoreApplication.translate("RobustarLauncher", u"resnet-18", None))
-        self.archComboBox.setItemText(1, QCoreApplication.translate("RobustarLauncher", u"resnet-34", None))
-        self.archComboBox.setItemText(2, QCoreApplication.translate("RobustarLauncher", u"resnet-50", None))
-        self.archComboBox.setItemText(3, QCoreApplication.translate("RobustarLauncher", u"resnet-101", None))
-        self.archComboBox.setItemText(4, QCoreApplication.translate("RobustarLauncher", u"resnet-152", None))
-        self.archComboBox.setItemText(5, QCoreApplication.translate("RobustarLauncher", u"resnet-18-32x32", None))
-        self.archComboBox.setItemText(6, QCoreApplication.translate("RobustarLauncher", u"mobilenet-v2", None))
-        self.archComboBox.setItemText(7, QCoreApplication.translate("RobustarLauncher", u"alexnet", None))
+        self.influencePathButton.setText(
+            QCoreApplication.translate("RobustarLauncher", "...", None)
+        )
+        self.dockerGroupBox_2.setTitle(
+            QCoreApplication.translate("RobustarLauncher", "Model", None)
+        )
+        # if QT_CONFIG(tooltip)
+        self.label_4.setToolTip(
+            QCoreApplication.translate(
+                "RobustarLauncher", "The architecture of the model", None
+            )
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.label_4.setText(
+            QCoreApplication.translate("RobustarLauncher", "Architecture", None)
+        )
+        self.archComboBox.setItemText(
+            0, QCoreApplication.translate("RobustarLauncher", "resnet-18", None)
+        )
+        self.archComboBox.setItemText(
+            1, QCoreApplication.translate("RobustarLauncher", "resnet-34", None)
+        )
+        self.archComboBox.setItemText(
+            2, QCoreApplication.translate("RobustarLauncher", "resnet-50", None)
+        )
+        self.archComboBox.setItemText(
+            3, QCoreApplication.translate("RobustarLauncher", "resnet-101", None)
+        )
+        self.archComboBox.setItemText(
+            4, QCoreApplication.translate("RobustarLauncher", "resnet-152", None)
+        )
+        self.archComboBox.setItemText(
+            5, QCoreApplication.translate("RobustarLauncher", "resnet-18-32x32", None)
+        )
+        self.archComboBox.setItemText(
+            6, QCoreApplication.translate("RobustarLauncher", "mobilenet-v2", None)
+        )
+        self.archComboBox.setItemText(
+            7, QCoreApplication.translate("RobustarLauncher", "alexnet", None)
+        )
 
-        self.archComboBox.setCurrentText(QCoreApplication.translate("RobustarLauncher", u"resnet-18", None))
+        self.archComboBox.setCurrentText(
+            QCoreApplication.translate("RobustarLauncher", "resnet-18", None)
+        )
         self.archComboBox.setProperty("placeholderText", "")
-#if QT_CONFIG(tooltip)
-        self.label_9.setToolTip(QCoreApplication.translate("RobustarLauncher", u"Check the box if you want a model with pretrained weights", None))
-#endif // QT_CONFIG(tooltip)
-        self.label_9.setText(QCoreApplication.translate("RobustarLauncher", u"Pretrained", None))
+        # if QT_CONFIG(tooltip)
+        self.label_9.setToolTip(
+            QCoreApplication.translate(
+                "RobustarLauncher",
+                "Check the box if you want a model with pretrained weights",
+                None,
+            )
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.label_9.setText(
+            QCoreApplication.translate("RobustarLauncher", "Pretrained", None)
+        )
         self.pretrainedCheckBox.setText("")
-#if QT_CONFIG(tooltip)
-        self.label_16.setToolTip(QCoreApplication.translate("RobustarLauncher", u"The weight file used to initialize the model. Optional weight files are under the root path of the checkpoint you set", None))
-#endif // QT_CONFIG(tooltip)
-        self.label_16.setText(QCoreApplication.translate("RobustarLauncher", u"Weight File", None))
-        self.weightFileComboBox.setItemText(0, QCoreApplication.translate("RobustarLauncher", u"None", None))
+        # if QT_CONFIG(tooltip)
+        self.label_16.setToolTip(
+            QCoreApplication.translate(
+                "RobustarLauncher",
+                "The weight file used to initialize the model. Optional weight files are under the root path of the checkpoint you set",
+                None,
+            )
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.label_16.setText(
+            QCoreApplication.translate("RobustarLauncher", "Weight File", None)
+        )
+        self.weightFileComboBox.setItemText(
+            0, QCoreApplication.translate("RobustarLauncher", "None", None)
+        )
 
         self.weightFileComboBox.setProperty("placeholderText", "")
-#if QT_CONFIG(tooltip)
-        self.label_19.setToolTip(QCoreApplication.translate("RobustarLauncher", u"The device on which the model will be created", None))
-#endif // QT_CONFIG(tooltip)
-        self.label_19.setText(QCoreApplication.translate("RobustarLauncher", u"Device", None))
-        self.deviceInput.setText(QCoreApplication.translate("RobustarLauncher", u"cpu", None))
-#if QT_CONFIG(tooltip)
-        self.label_20.setToolTip(QCoreApplication.translate("RobustarLauncher", u"Check the box if you want the train data to be shuffled", None))
-#endif // QT_CONFIG(tooltip)
-        self.label_20.setText(QCoreApplication.translate("RobustarLauncher", u"Shuffle", None))
+        # if QT_CONFIG(tooltip)
+        self.label_19.setToolTip(
+            QCoreApplication.translate(
+                "RobustarLauncher",
+                "The device on which the model will be created",
+                None,
+            )
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.label_19.setText(
+            QCoreApplication.translate("RobustarLauncher", "Device", None)
+        )
+        self.deviceInput.setText(
+            QCoreApplication.translate("RobustarLauncher", "cpu", None)
+        )
+        # if QT_CONFIG(tooltip)
+        self.label_20.setToolTip(
+            QCoreApplication.translate(
+                "RobustarLauncher",
+                "Check the box if you want the train data to be shuffled",
+                None,
+            )
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.label_20.setText(
+            QCoreApplication.translate("RobustarLauncher", "Shuffle", None)
+        )
         self.shuffleCheckBox.setText("")
-#if QT_CONFIG(tooltip)
-        self.label_21.setToolTip(QCoreApplication.translate("RobustarLauncher", u"The batch size of the data", None))
-#endif // QT_CONFIG(tooltip)
-        self.label_21.setText(QCoreApplication.translate("RobustarLauncher", u"Batch Size", None))
+        # if QT_CONFIG(tooltip)
+        self.label_21.setToolTip(
+            QCoreApplication.translate(
+                "RobustarLauncher", "The batch size of the data", None
+            )
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.label_21.setText(
+            QCoreApplication.translate("RobustarLauncher", "Batch Size", None)
+        )
         self.batchSizeInput.setText("")
-#if QT_CONFIG(tooltip)
-        self.label_22.setToolTip(QCoreApplication.translate("RobustarLauncher", u"The number of workers for the data loader", None))
-#endif // QT_CONFIG(tooltip)
-        self.label_22.setText(QCoreApplication.translate("RobustarLauncher", u"Worker Number", None))
+        # if QT_CONFIG(tooltip)
+        self.label_22.setToolTip(
+            QCoreApplication.translate(
+                "RobustarLauncher", "The number of workers for the data loader", None
+            )
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.label_22.setText(
+            QCoreApplication.translate("RobustarLauncher", "Worker Number", None)
+        )
         self.workerNumberInput.setText("")
-#if QT_CONFIG(tooltip)
-        self.label_25.setToolTip(QCoreApplication.translate("RobustarLauncher", u"The number of classes of the data", None))
-#endif // QT_CONFIG(tooltip)
-        self.label_25.setText(QCoreApplication.translate("RobustarLauncher", u"Class Number", None))
+        # if QT_CONFIG(tooltip)
+        self.label_25.setToolTip(
+            QCoreApplication.translate(
+                "RobustarLauncher", "The number of classes of the data", None
+            )
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.label_25.setText(
+            QCoreApplication.translate("RobustarLauncher", "Class Number", None)
+        )
         self.classNumberInput.setText("")
-#if QT_CONFIG(tooltip)
-        self.label_23.setToolTip(QCoreApplication.translate("RobustarLauncher", u"The length of side of the input image of the model", None))
-#endif // QT_CONFIG(tooltip)
-        self.label_23.setText(QCoreApplication.translate("RobustarLauncher", u"Image Size", None))
+        # if QT_CONFIG(tooltip)
+        self.label_23.setToolTip(
+            QCoreApplication.translate(
+                "RobustarLauncher",
+                "The length of side of the input image of the model",
+                None,
+            )
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.label_23.setText(
+            QCoreApplication.translate("RobustarLauncher", "Image Size", None)
+        )
         self.imgSizeInput.setText("")
-#if QT_CONFIG(tooltip)
-        self.label_24.setToolTip(QCoreApplication.translate("RobustarLauncher", u"The mode of padding", None))
-#endif // QT_CONFIG(tooltip)
-        self.label_24.setText(QCoreApplication.translate("RobustarLauncher", u"Image Padding", None))
-        self.paddingComboBox.setItemText(0, QCoreApplication.translate("RobustarLauncher", u"short side", None))
-        self.paddingComboBox.setItemText(1, QCoreApplication.translate("RobustarLauncher", u"none", None))
+        # if QT_CONFIG(tooltip)
+        self.label_24.setToolTip(
+            QCoreApplication.translate("RobustarLauncher", "The mode of padding", None)
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.label_24.setText(
+            QCoreApplication.translate("RobustarLauncher", "Image Padding", None)
+        )
+        self.paddingComboBox.setItemText(
+            0, QCoreApplication.translate("RobustarLauncher", "short side", None)
+        )
+        self.paddingComboBox.setItemText(
+            1, QCoreApplication.translate("RobustarLauncher", "none", None)
+        )
 
-        self.paddingComboBox.setCurrentText(QCoreApplication.translate("RobustarLauncher", u"short side", None))
+        self.paddingComboBox.setCurrentText(
+            QCoreApplication.translate("RobustarLauncher", "short side", None)
+        )
         self.paddingComboBox.setProperty("placeholderText", "")
-        self.tabWidget.setTabText(self.tabWidget.indexOf(self.createTab), QCoreApplication.translate("RobustarLauncher", u"Create", None))
-        self.groupBox_2.setTitle(QCoreApplication.translate("RobustarLauncher", u"Exited", None))
-        self.groupBox_3.setTitle(QCoreApplication.translate("RobustarLauncher", u"Created", None))
-        self.groupBox.setTitle(QCoreApplication.translate("RobustarLauncher", u"Running", None))
-        self.refreshListWidgetsButton.setText(QCoreApplication.translate("RobustarLauncher", u"Refresh", None))
-        self.tabWidget.setTabText(self.tabWidget.indexOf(self.manageTab), QCoreApplication.translate("RobustarLauncher", u"Manage", None))
-        self.tabWidget_2.setTabText(self.tabWidget_2.indexOf(self.tab), QCoreApplication.translate("RobustarLauncher", u"Prompts", None))
-        self.tabWidget_2.setTabText(self.tabWidget_2.indexOf(self.tab_2), QCoreApplication.translate("RobustarLauncher", u"Details", None))
-        self.tabWidget_2.setTabText(self.tabWidget_2.indexOf(self.tab_3), QCoreApplication.translate("RobustarLauncher", u"Logs", None))
-    # retranslateUi
+        self.tabWidget.setTabText(
+            self.tabWidget.indexOf(self.createTab),
+            QCoreApplication.translate("RobustarLauncher", "Create", None),
+        )
+        self.groupBox_2.setTitle(
+            QCoreApplication.translate("RobustarLauncher", "Exited", None)
+        )
+        self.groupBox_3.setTitle(
+            QCoreApplication.translate("RobustarLauncher", "Created", None)
+        )
+        self.groupBox.setTitle(
+            QCoreApplication.translate("RobustarLauncher", "Running", None)
+        )
+        self.refreshListWidgetsButton.setText(
+            QCoreApplication.translate("RobustarLauncher", "Refresh", None)
+        )
+        self.tabWidget.setTabText(
+            self.tabWidget.indexOf(self.manageTab),
+            QCoreApplication.translate("RobustarLauncher", "Manage", None),
+        )
+        self.tabWidget_2.setTabText(
+            self.tabWidget_2.indexOf(self.tab),
+            QCoreApplication.translate("RobustarLauncher", "Prompts", None),
+        )
+        self.tabWidget_2.setTabText(
+            self.tabWidget_2.indexOf(self.tab_2),
+            QCoreApplication.translate("RobustarLauncher", "Details", None),
+        )
+        self.tabWidget_2.setTabText(
+            self.tabWidget_2.indexOf(self.tab_3),
+            QCoreApplication.translate("RobustarLauncher", "Logs", None),
+        )
 
+    # retranslateUi

--- a/scripts/example.sh
+++ b/scripts/example.sh
@@ -6,6 +6,7 @@
 # -a "cuda11.1-0.1.0-beta" \
 # -t "/Robustar2/dataset/train" \
 # -e "/Robustar2/dataset/test" \
+# -d "/Robustar2/dataset/test" \
 # -i "/Robustar2/influence_images" \
 # -o "/Robustar2/configs.json" \
 # -c "/Robustar2/checkpoints" 
@@ -17,6 +18,7 @@
 -p 8080 \
 -t C:\\Robustar2\\dataset\\train \
 -e C:\\Robustar2\\dataset\\test \
+-d C:\\Robustar2\\dataset\\test \
 -i C:\\Robustar2\\influence_images \
 -c C:\\Robustar2\\checkpoints \
 -o C:\\Robustar2\\configs.json

--- a/scripts/robustar.sh
+++ b/scripts/robustar.sh
@@ -15,6 +15,7 @@ OPT_NAME=robustar
 RUN_MODE='HELP'
 TRAIN_FOLDER='./'
 TEST_FOLDER='./'
+VALIDATION_FOLDER='./'
 INFLU_FOLDER='./'
 CHECK_FOLDER='./'
 CONFIG_FILE='configs.json'
@@ -70,6 +71,7 @@ function RUN {
     -p 127.0.0.1:${OPT_PORT}:80 \
     --mount type=bind,source=${TRAIN_FOLDER},target=/Robustar2/dataset/train \
     --mount type=bind,source=${TEST_FOLDER},target=/Robustar2/dataset/test \
+    --mount type=bind,source=${VALIDATION_FOLDER},target=/Robustar2/dataset/validation \
     --mount type=bind,source=${INFLU_FOLDER},target=/Robustar2/influence_images \
     --mount type=bind,source=${CHECK_FOLDER},target=/Robustar2/checkpoint_images \
     -v $CONFIG_FILE:/Robustar2/configs.json \
@@ -83,6 +85,7 @@ function RUN_GPU {
     -p 127.0.0.1:${OPT_PORT}:80 \
     --mount type=bind,source=${TRAIN_FOLDER},target=/Robustar2/dataset/train \
     --mount type=bind,source=${TEST_FOLDER},target=/Robustar2/dataset/test \
+    --mount type=bind,source=${VALIDATION_FOLDER},target=/Robustar2/dataset/validation \
     --mount type=bind,source=${INFLU_FOLDER},target=/Robustar2/influence_images \
     --mount type=bind,source=${CHECK_FOLDER},target=/Robustar2/checkpoint_images \
     -v $CONFIG_FILE:/Robustar2/configs.json \
@@ -119,6 +122,9 @@ while getopts :m:p:a:n:t:e:i:c:o:h FLAG; do
       ;;
     e)
       TEST_FOLDER=$OPTARG
+      ;;
+    d)
+      VALIDATION_FOLDER=$OPTARG
       ;;
     i)
       INFLU_FOLDER=$OPTARG


### PR DESCRIPTION
For issue #99 

Now user can specify a validation set to use when starting a container.  

**Note for reviewers**: I seem to have triggered the python linter, which changed a lot of stuff in `main_ctrl.py`. The only change I made to that file was adding a function around line 73 (see below), and please ignore other changes in that file.

```
    def setMValidationPath(self):
        path = QFileDialog.getExistingDirectory(
            self.mainView, "Choose Validation Set Path", self.model.cwd
        )
        self.model.cwd = os.path.dirname(path)
        if path:
            self.model.validationPath = path
```


![image](https://user-images.githubusercontent.com/33018020/210320348-a402720c-91eb-43cc-84a1-97adfa98aa93.png)
