### PR TITLE
Click on outside the task pannel

### DIFF
--- a/front-end/cypress/tests/components/auto_annotate_pad.spec.js
+++ b/front-end/cypress/tests/components/auto_annotate_pad.spec.js
@@ -20,6 +20,7 @@ describe('Auto Annotate Pad', () => {
     cy.getBySel('auto-annotate-pad-start-auto-annotation').click();
 
     // This will wait for max 120 seconds until the task is finished
+    cy.getBySel('header-toggle-tasks-panel').click();
     cy.get('[data-test=task-panel-task-done]', { timeout: 120 * 1000 }).click();
     cy.get('[data-test=task-center-p-no-task]');
 
@@ -37,6 +38,7 @@ describe('Auto Annotate Pad', () => {
     cy.clickBySel('header-toggle-tasks-panel');
     cy.getBySel('auto-annotate-end-index').clear().type('500');
     cy.clickBySel('auto-annotate-pad-start-auto-annotation');
+    cy.clickBySel('header-toggle-tasks-panel');
     cy.getBySel('task-panel-item-name').children().should('have.length', 1);
     cy.clickBySel('task-panel-stop-task');
     cy.getBySel('task-center-p-no-task').should('be.visible');
@@ -46,6 +48,7 @@ describe('Auto Annotate Pad', () => {
     cy.getBySel('header-toggle-tasks-panel').click();
     cy.getBySel('auto-annotate-end-index').clear().type('0');
     cy.clickBySel('auto-annotate-pad-start-auto-annotation');
+    cy.getBySel('header-toggle-tasks-panel').click();
     cy.getBySel('task-center-p-no-task').should('be.visible');
   });
 
@@ -53,6 +56,7 @@ describe('Auto Annotate Pad', () => {
     cy.getBySel('header-toggle-tasks-panel').click();
     cy.getBySel('auto-annotate-end-index').clear().type('0999').click();
     cy.clickBySel('auto-annotate-pad-start-auto-annotation');
+    cy.getBySel('header-toggle-tasks-panel').click();
     cy.getBySel('task-panel-progress-linear').should('contain', '999');
     cy.clickBySel('task-panel-stop-task');
     cy.getBySel('task-center-p-no-task').should('be.visible');
@@ -62,6 +66,7 @@ describe('Auto Annotate Pad', () => {
     cy.getBySel('header-toggle-tasks-panel').click();
     cy.getBySel('auto-annotate-end-index').clear().type('9999');
     cy.clickBySel('auto-annotate-pad-start-auto-annotation');
+    cy.getBySel('header-toggle-tasks-panel').click();
     cy.getBySel('task-panel-item-name').children().should('have.length', 1);
     cy.getBySel('task-panel-progress-linear').should('contain', '9000');
     cy.clickBySel('task-panel-stop-task');
@@ -72,6 +77,7 @@ describe('Auto Annotate Pad', () => {
     cy.getBySel('header-toggle-tasks-panel').click();
     cy.getBySel('auto-annotate-end-index').clear().type('9.9');
     cy.clickBySel('auto-annotate-pad-start-auto-annotation');
+    cy.getBySel('header-toggle-tasks-panel').click();
     cy.getBySel('task-center-p-no-task').should('be.visible');
   });
 
@@ -79,6 +85,7 @@ describe('Auto Annotate Pad', () => {
     cy.getBySel('header-toggle-tasks-panel').click();
     cy.getBySel('auto-annotate-start-index').clear().type('-1');
     cy.getBySel('auto-annotate-pad-start-auto-annotation').click();
+    cy.getBySel('header-toggle-tasks-panel').click();
     cy.getBySel('task-center-p-no-task').should('be.visible');
   });
 
@@ -86,6 +93,7 @@ describe('Auto Annotate Pad', () => {
     cy.getBySel('header-toggle-tasks-panel').click();
     cy.getBySel('auto-annotate-end-index').clear().type('-2');
     cy.getBySel('auto-annotate-pad-start-auto-annotation').click();
+    cy.getBySel('header-toggle-tasks-panel').click();
     cy.getBySel('task-center-p-no-task').should('be.visible');
   });
 
@@ -94,6 +102,7 @@ describe('Auto Annotate Pad', () => {
     cy.getBySel('auto-annotate-start-index').clear().type('99999');
     cy.getBySel('auto-annotate-end-index').clear().type('99998');
     cy.getBySel('auto-annotate-pad-start-auto-annotation').click();
+    cy.getBySel('header-toggle-tasks-panel').click();
     cy.getBySel('task-center-p-no-task').should('be.visible');
   });
 });

--- a/front-end/packages/robustar/src/App.vue
+++ b/front-end/packages/robustar/src/App.vue
@@ -4,7 +4,7 @@
     <SideBar></SideBar>
 
     <v-main class="page-content">
-      <TaskPanel :style="{ visibility: isTaskspanelHidden ? 'hidden' : 'visible' }"></TaskPanel>
+      <TaskPanel v-if="!isTaskspanelHidden" v-click-outside="onClickOutside"></TaskPanel>
       <Notification></Notification>
       <router-view />
     </v-main>
@@ -29,6 +29,11 @@ export default {
   methods: {
     toggleTaskspanel() {
       this.isTaskspanelHidden = !this.isTaskspanelHidden;
+    },
+    onClickOutside() {
+      if (this.isTaskspanelHidden==false) {
+        this.isTaskspanelHidden = true;
+      }
     },
   },
   data() {


### PR DESCRIPTION
Resolves issue #104 

Added the feature to collapse panel task when clicking outside the panel, and modify the front-end tests correspondingly.