### PR TITLE
fixed wrong accuracy issue when loading a trained model

### DIFF
--- a/back-end/modules/ml/trainer.py
+++ b/back-end/modules/ml/trainer.py
@@ -199,7 +199,6 @@ class Trainer:
                     print("Training stopped!")
                     return
 
-            # save_net(net)
             print("Epoch Finish!")
             eepoch = time.time()
             print(

--- a/back-end/utils/test.py
+++ b/back-end/utils/test.py
@@ -43,10 +43,12 @@ class TestThread(threading.Thread):
         incorrect_buffer = []
 
         task = RTask(TaskType.Test, dataset_length)
+        model_wrapper = RServer.get_model_wrapper()
+        model_wrapper.model.eval()
         for img_path, label in samples:
 
             output = get_image_prediction(
-                RServer.get_model_wrapper(),
+                model_wrapper,
                 img_path,
                 self.dataManager.image_size,
                 argmax=False,


### PR DESCRIPTION
## Issue ticket number and link

Tag relevant issues and PRs as follows

- Part of issue #159 .

## What are the changes

> Model weights not loaded properly. Loading a trained model by name prints success message, but the test accuracy is the same as a randomly initialized model.

The model weights were correctly loaded and I was confused about the cause at first. After some struggle it turned out that the bug was very simple: we did not call `model.eval` before evaluation. Failing to do so will mess up things such as dropout and batchnorm layers, which results in bad predictions.

## Checklist before requesting a review

- [x] Double check the diff between my branch and the target branch. Make sure there's nothing unexpected.
- [x] Tag relevant issues and PRs in the first section of this form.
- [x] All CI tests are passed.
- [x] No `package-lock.json` or `package.json` changes are pushed. If you do, add a new section `Dependency Changes` to the form stating what library changes are introduced and why.
