### PR TITLE
Fixed issue #213: allowed variable `num_classes` for pre-trained models

### DIFF
--- a/back-end/objects/RModelWrapper.py
+++ b/back-end/objects/RModelWrapper.py
@@ -318,7 +318,7 @@ class RModelWrapper:
             init_func, weights = MODEL2INIT[network_type]
             weights = weights if pretrained else None
             model = init_func(weights=weights)
-            if self.num_classes != 1000:
+            if self.num_classes != IMAGENET_OUTPUT_SIZE:
                 self.replace_output_layer(model, self.num_classes)
 
         return model.to(self.device)

--- a/back-end/objects/RModelWrapper.py
+++ b/back-end/objects/RModelWrapper.py
@@ -20,6 +20,19 @@ MODEL_INPUT_SHAPE = {
     "alexnet": 227,
 }
 
+MODEL2INIT = {
+    "resnet-18": (torchvision.models.resnet18, "ResNet18_Weights.IMAGENET1K_V1"),
+    "resnet-34": (torchvision.models.resnet34, "ResNet34_Weights.IMAGENET1K_V1"),
+    "resnet-50": (torchvision.models.resnet50, "ResNet50_Weights.IMAGENET1K_V1"),
+    "resnet-101": (torchvision.models.resnet101, "ResNet101_Weights.IMAGENET1K_V1"),
+    "resnet-152": (torchvision.models.resnet152, "ResNet152_Weights.IMAGENET1K_V1"),
+    "mobilenet-v2": (
+        torchvision.models.mobilenet_v2,
+        "MobileNet_V2_Weights.IMAGENET1K_V1",
+    ),
+    "alexnet": (torchvision.models.alexnet, "AlexNet_Weights.IMAGENET1K_V1"),
+}
+
 AVAILABLE_MODELS = list(MODEL_INPUT_SHAPE.keys())
 
 
@@ -106,7 +119,7 @@ class RModelWrapper:
         # Check if the current model is idle
         if not self.is_model_available():
             raise Exception("Failed to switch model because the current model is busy.")
-        
+
         del self.model
         self.model = None
         self.model_name = None
@@ -290,37 +303,8 @@ class RModelWrapper:
             raise Exception(
                 f"Requested model type {network_type} not supported. Please check."
             )
-        # If the model is pretrained, it should have the same number of classes as the ImageNet model
-        if pretrained and self.num_classes != IMAGENET_OUTPUT_SIZE:
-            raise Exception(
-                f"Pretrained model is supposed to have {IMAGENET_OUTPUT_SIZE} classes as output."
-            )
 
-        if network_type == "resnet-18":
-            model = torchvision.models.resnet18(
-                pretrained=pretrained, num_classes=self.num_classes
-            )
-        elif network_type == "resnet-34":
-            model = torchvision.models.resnet34(
-                pretrained=pretrained, num_classes=self.num_classes
-            )
-        elif network_type == "resnet-50":
-            model = torchvision.models.resnet50(
-                pretrained=pretrained, num_classes=self.num_classes
-            )
-        elif network_type == "resnet-101":
-            model = torchvision.models.resnet101(
-                pretrained=pretrained, num_classes=self.num_classes
-            )
-        elif network_type == "resnet-152":
-            model = torchvision.models.resnet152(
-                pretrained=pretrained, num_classes=self.num_classes
-            )
-        elif network_type == "mobilenet-v2":
-            model = torchvision.models.mobilenet_v2(
-                pretrained=pretrained, num_classes=self.num_classes
-            )
-        elif network_type == "resnet-18-32x32":
+        if network_type == "resnet-18-32x32":
             model = torchvision.models.ResNet(
                 torchvision.models.resnet.BasicBlock,
                 [2, 2, 2, 2],
@@ -330,12 +314,33 @@ class RModelWrapper:
                 3, 64, kernel_size=3, stride=1, padding=1, bias=False
             )
             model.maxpool = torch.nn.MaxPool2d(kernel_size=3, stride=1, padding=1)
-        elif network_type == "alexnet":
-            model = torchvision.models.alexnet(
-                pretrained=pretrained, num_classes=self.num_classes
-            )
+        elif network_type in MODEL2INIT:
+            init_func, weights = MODEL2INIT[network_type]
+            weights = weights if pretrained else None
+            model = init_func(weights=weights)
+            if self.num_classes != 1000:
+                self.replace_output_layer(model, self.num_classes)
 
         return model.to(self.device)
+
+    def replace_output_layer(self, model, num_classes):
+        """
+        Replace the output layer of the model with a new one that has num_classes as output
+        """
+        if isinstance(model, torchvision.models.ResNet):
+            model.fc = torch.nn.Linear(model.fc.in_features, num_classes)
+        elif isinstance(model, torchvision.models.MobileNetV2):
+            model.classifier[1] = torch.nn.Linear(
+                model.classifier[1].in_features, num_classes
+            )
+        elif isinstance(model, torchvision.models.AlexNet):
+            model.classifier[6] = torch.nn.Linear(
+                model.classifier[6].in_features, num_classes
+            )
+        else:
+            raise Exception(
+                "Model type not supported for replacing the output layer. Please check."
+            )
 
     def init_custom_model(self, code_path, name):
         """

--- a/back-end/tests/test_model.py
+++ b/back-end/tests/test_model.py
@@ -171,7 +171,7 @@ upload_test_cases = [
                 "tags": ["test", "CNN", "resnet"]
             }""",
         },
-        "expected_output": 400,
+        "expected_output": 200,
     },
     {
         "input": {
@@ -281,16 +281,18 @@ class TestModel:
         def test_model_upload(self, client, reset_db, basedir, test_data):
             input_data = test_data["input"].copy()
 
-            if "weight_file_path" in input_data:
+            if "weight_file" in input_data:
                 weight_file_path = os.path.join(basedir, input_data["weight_file"])
-                with open(weight_file_path, "rb") as f:
-                    input_data["weight_file"] = (
-                        FileStorage(stream=f, filename="SimpleCNN.pth"),
-                    )
+                f = open(weight_file_path, "rb")
+                input_data["weight_file"] = (
+                    FileStorage(stream=f, filename="SimpleCNN.pth"),
+                )
 
             response = client.post(
                 "/model", data=input_data, content_type="multipart/form-data"
             )
+            if "weight_file" in input_data:
+                f.close()
             assert response.status_code == test_data["expected_output"]
 
     class TestModelSwitch:
@@ -375,7 +377,7 @@ class TestModel:
             # Upload dummy models
             model_name = "model-delete-current"
             dummy_api_upload_dummy_model(client, model_name)
-            
+
             dummy_api_set_current_model(client, model_name)
 
             # Deleting current model
@@ -385,4 +387,3 @@ class TestModel:
             # No current model is selected
             resp = dummy_api_get_current_model(client)
             assert resp.status_code == 400
-


### PR DESCRIPTION
## Issue ticket number and link

Tag relevant issues and PRs as follows

Issue #213 

## What are the changes

This update enables the use of pretrained model weights even when the `num_classes` parameter differs from the default value of 1000.

## Comments

By initializing models with the original number of classes and subsequently replacing the output layer, we have resolved compatibility issues related to `num_classes`. This approach allows for the flexible adaptation of pretrained models to different classification tasks.

## Checklist before requesting a review

- [x] Double check the diff between my branch and the target branch. Make sure there's nothing unexpected.
- [x] Tag relevant issues and PRs in the first section of this form.
- [x] All CI tests are passed.
- [x] No `package-lock.json` or `package.json` changes are pushed. If you do, add a new section `Dependency Changes` to the form stating what library changes are introduced and why.
